### PR TITLE
Add tests for orders routes

### DIFF
--- a/ExpressBackend/package.json
+++ b/ExpressBackend/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "main": "server.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "jest",
     "start": "node server.js",
     "nodemon": "nodemon server.js"
   },
@@ -28,5 +28,9 @@
     "pg": "^8.15.6",
     "sequelize": "^6.37.7",
     "uuid": "^11.1.0"
+  },
+  "devDependencies": {
+    "jest": "^30.0.4",
+    "supertest": "^7.1.3"
   }
 }

--- a/ExpressBackend/server.js
+++ b/ExpressBackend/server.js
@@ -37,6 +37,10 @@ app.use('/cart', cartRouter)
 app.use('/orders', orderRouter)
 
 //server execute
-app.listen(5000, () => {
-  console.log(`server running on port 5000`)
-})
+if (require.main === module) {
+  app.listen(5000, () => {
+    console.log(`server running on port 5000`)
+  })
+}
+
+module.exports = app

--- a/ExpressBackend/tests/orders.test.js
+++ b/ExpressBackend/tests/orders.test.js
@@ -1,0 +1,33 @@
+const request = require('supertest')
+
+// Mock native modules that require binaries
+jest.mock('bcrypt', () => ({
+  hash: jest.fn(),
+  compare: jest.fn()
+}))
+
+jest.mock('../models/pool', () => ({
+  query: jest.fn()
+}))
+
+const pool = require('../models/pool')
+const app = require('../server')
+
+describe('Orders API', () => {
+  beforeEach(() => {
+    pool.query.mockReset()
+  })
+
+  test('GET /orders/order/:orderId returns 404 for non-existent ID', async () => {
+    pool.query.mockResolvedValueOnce({ rows: [] })
+    const res = await request(app).get('/orders/order/999')
+    expect(res.statusCode).toBe(404)
+  })
+
+  test('GET /orders/:userId returns an array', async () => {
+    pool.query.mockResolvedValueOnce({ rows: [] })
+    const res = await request(app).get('/orders/1')
+    expect(res.statusCode).toBe(200)
+    expect(Array.isArray(res.body)).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary
- export Express `app` in `server.js` for test usage
- add Jest & Supertest dev dependencies and update test script
- create `orders.test.js` with tests for order endpoints

## Testing
- `npm install --no-save jest supertest`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6879710fab288327ab21876700a5237d