### PR TITLE
Fix order routes paths

### DIFF
--- a/ExpressBackend/routes/orders.js
+++ b/ExpressBackend/routes/orders.js
@@ -12,16 +12,15 @@ const {
 // ✅ Place a new order
 router.post('/', placeOrder)
 
-// ✅ Get all orders by user ID
-router.get('/:userId', getOrdersByUserId)
-
 // ✅ Get single order by order ID
 router.get('/order/:orderId', getOrderById)
+// ✅ Get all orders by user ID
+router.get('/:userId', getOrdersByUserId)
 
 // ✅ Update order status
 router.put('/:orderId/status', updateOrderStatus)
 
-router.patch('orders/order/:id/cancel', cancelOrder)
+router.patch('/order/:id/cancel', cancelOrder)
 // ✅ Delete an order
 router.delete('/:orderId', deleteOrder)
 


### PR DESCRIPTION
## Summary
- reorder get order-by-id route above `/:userId` route
- correct cancellation patch route path

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687970f6729c8327be8740eee3c3eaa8