### PR TITLE
Fix route conflict in order endpoints

### DIFF
--- a/ExpressBackend/routes/orders.js
+++ b/ExpressBackend/routes/orders.js
@@ -12,16 +12,18 @@ const {
 // ✅ Place a new order
 router.post('/', placeOrder)
 
-// ✅ Get all orders by user ID
-router.get('/:userId', getOrdersByUserId)
-
 // ✅ Get single order by order ID
 router.get('/order/:orderId', getOrderById)
+
+// ✅ Cancel order
+router.patch('/order/:id/cancel', cancelOrder)
+
+// ✅ Get all orders by user ID
+router.get('/:userId', getOrdersByUserId)
 
 // ✅ Update order status
 router.put('/:orderId/status', updateOrderStatus)
 
-router.patch('orders/order/:id/cancel', cancelOrder)
 // ✅ Delete an order
 router.delete('/:orderId', deleteOrder)
 


### PR DESCRIPTION
## Summary
- correct path for cancel order endpoint
- reorder order routes so `/order/:id` is matched before the generic user route

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68796f289e7c83278c23dc524aab86ee