### PR TITLE
Use env vars for API URLs

### DIFF
--- a/WebsiteAdmin/.env.example
+++ b/WebsiteAdmin/.env.example
@@ -1,0 +1,2 @@
+VITE_API_URL=http://localhost:5000
+VITE_APP_URL=http://localhost:3000

--- a/WebsiteAdmin/src/addingAdmin/Create.jsx
+++ b/WebsiteAdmin/src/addingAdmin/Create.jsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
+import { API_URL } from '../config'
 
 function Create() {
   const [password, setPassword] = useState('') // for both admin and salon password
@@ -9,7 +10,7 @@ function Create() {
   const handleAdminSubmit = async (e) => {
     e.preventDefault()
     try {
-      const res = await fetch('http://localhost:5000/admins/register', {
+      const res = await fetch(`${API_URL}/admins/register`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json'

--- a/WebsiteAdmin/src/addingAdmin/Edit.jsx
+++ b/WebsiteAdmin/src/addingAdmin/Edit.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
+import { API_URL } from '../config'
 
 function Edit() {
   const [username, setUsername] = useState('')
@@ -12,7 +13,7 @@ function Edit() {
   useEffect(() => {
     const fetchAdmin = async () => {
       try {
-        const res = await fetch(`http://localhost:5000/admins/${id}`)
+        const res = await fetch(`${API_URL}/admins/${id}`)
         const data = await res.json()
 
         if (res.ok) {
@@ -42,7 +43,7 @@ function Edit() {
     setError('')
 
     try {
-      const res = await fetch(`http://localhost:5000/admins/${id}`, {
+      const res = await fetch(`${API_URL}/admins/${id}`, {
         method: 'PUT',
         headers: {
           'Content-Type': 'application/json'

--- a/WebsiteAdmin/src/addingAdmin/Get.jsx
+++ b/WebsiteAdmin/src/addingAdmin/Get.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react'
 import { useNavigate, useLocation, Link } from 'react-router-dom'
 import axios from 'axios'
+import { API_URL } from '../config'
 
 const Gets = () => {
   const [admins, setAdmins] = useState([])
@@ -13,7 +14,7 @@ const Gets = () => {
   const fetchAdmins = async () => {
     try {
       const token = localStorage.getItem('authToken')
-      const response = await axios.get('http://localhost:5000/admins', {
+      const response = await axios.get(`${API_URL}/admins`, {
         headers: { Authorization: `Bearer ${token}` }
       })
       setAdmins(response.data)
@@ -31,7 +32,7 @@ const Gets = () => {
     if (!adminToDelete) return
     try {
       const token = localStorage.getItem('authToken')
-      await axios.delete(`http://localhost:5000/admins/${adminToDelete.id}`, {
+      await axios.delete(`${API_URL}/admins/${adminToDelete.id}`, {
         headers: { Authorization: `Bearer ${token}` }
       })
       setAdmins(admins.filter((a) => a.id !== adminToDelete.id))

--- a/WebsiteAdmin/src/addingSalon/ApprovalHistory.jsx
+++ b/WebsiteAdmin/src/addingSalon/ApprovalHistory.jsx
@@ -1,5 +1,6 @@
 import { useParams } from 'react-router-dom'
 import { useEffect, useState } from 'react'
+import { API_URL } from '../config'
 
 export default function ApprovalHistory() {
   const { salonId } = useParams()
@@ -7,7 +8,7 @@ export default function ApprovalHistory() {
   const [error, setError] = useState(null)
 
   useEffect(() => {
-    fetch(`http://localhost:5000/approval/history/${salonId}`)
+    fetch(`${API_URL}/approval/history/${salonId}`)
       .then(async (res) => {
         if (!res.ok) {
           const text = await res.text()

--- a/WebsiteAdmin/src/addingSalon/Create.jsx
+++ b/WebsiteAdmin/src/addingSalon/Create.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
+import { API_URL } from '../config'
 import { MapContainer, TileLayer, Marker, useMapEvents } from 'react-leaflet'
 import 'leaflet/dist/leaflet.css'
 import L from 'leaflet'
@@ -59,7 +60,7 @@ function Create() {
     formData.append('location', JSON.stringify({ latitude, longitude }))
 
     try {
-      const res = await fetch('http://localhost:5000/salons/register', {
+      const res = await fetch(`${API_URL}/salons/register`, {
         method: 'POST',
         body: formData
       })

--- a/WebsiteAdmin/src/addingSalon/Edit.jsx
+++ b/WebsiteAdmin/src/addingSalon/Edit.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
+import { API_URL } from '../config'
 import { MapContainer, TileLayer, Marker, useMapEvents } from 'react-leaflet'
 import 'leaflet/dist/leaflet.css'
 import L from 'leaflet'
@@ -39,7 +40,7 @@ function Edit() {
   useEffect(() => {
     const fetchSalon = async () => {
       try {
-        const res = await fetch(`http://localhost:5000/salons/${id}`)
+        const res = await fetch(`${API_URL}/salons/${id}`)
         const data = await res.json()
 
         if (res.ok && data) {
@@ -77,7 +78,7 @@ function Edit() {
     if (image) formData.append('image', image)
 
     try {
-      const res = await fetch(`http://localhost:5000/salons/${id}`, {
+      const res = await fetch(`${API_URL}/salons/${id}`, {
         method: 'PUT',
         body: formData
       })

--- a/WebsiteAdmin/src/addingSalon/Get.jsx
+++ b/WebsiteAdmin/src/addingSalon/Get.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import { useNavigate, useLocation, Link } from 'react-router-dom'
+import { API_URL } from '../config'
 
 function Get() {
   const [salons, setSalons] = useState([])
@@ -13,8 +14,8 @@ function Get() {
     const fetchData = async () => {
       try {
         const [salonRes, typeRes] = await Promise.all([
-          fetch('http://localhost:5000/salons'),
-          fetch('http://localhost:5000/types/type') // this returns salons + types grouped
+          fetch(`${API_URL}/salons`),
+          fetch(`${API_URL}/types/type`) // this returns salons + types grouped
         ])
         const salonsData = await salonRes.json()
         const typesData = await typeRes.json()
@@ -49,8 +50,8 @@ function Get() {
   // Approve or unapprove salon
   const handleApprove = async (id, isCurrentlyApproved) => {
     const endpoint = isCurrentlyApproved
-      ? 'http://localhost:5000/approval/unapprove'
-      : 'http://localhost:5000/approval/approve'
+      ? `${API_URL}/approval/unapprove`
+      : `${API_URL}/approval/approve`
 
     try {
       const res = await fetch(endpoint, {
@@ -80,7 +81,7 @@ function Get() {
     if (!salonToDelete) return
     try {
       const res = await fetch(
-        `http://localhost:5000/salons/${salonToDelete.id}`,
+        `${API_URL}/salons/${salonToDelete.id}`,
         { method: 'DELETE' }
       )
       if (res.ok) {

--- a/WebsiteAdmin/src/addingUser/Create.jsx
+++ b/WebsiteAdmin/src/addingUser/Create.jsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
+import { API_URL } from '../config'
 
 function Create() {
   const [username, setUsername] = useState('')
@@ -21,7 +22,7 @@ function Create() {
     setError('') // Clear previous errors
 
     try {
-      const res = await fetch('http://localhost:5000/users/register', {
+      const res = await fetch(`${API_URL}/users/register`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json'

--- a/WebsiteAdmin/src/addingUser/Edit.jsx
+++ b/WebsiteAdmin/src/addingUser/Edit.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
+import { API_URL } from '../config'
 
 function Edit() {
   const [username, setUsername] = useState('')
@@ -11,7 +12,7 @@ function Edit() {
   useEffect(() => {
     const fetchUser = async () => {
       try {
-        const res = await fetch(`http://localhost:5000/users/${id}`)
+        const res = await fetch(`${API_URL}/users/${id}`)
         const data = await res.json()
 
         if (res.ok) {
@@ -32,7 +33,7 @@ function Edit() {
   const handleSubmit = async (e) => {
     e.preventDefault()
     try {
-      const res = await fetch(`http://localhost:5000/users/${id}`, {
+      const res = await fetch(`${API_URL}/users/${id}`, {
         method: 'PUT',
         headers: {
           'Content-Type': 'application/json'

--- a/WebsiteAdmin/src/addingUser/Get.jsx
+++ b/WebsiteAdmin/src/addingUser/Get.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import { useNavigate, useLocation, Link } from 'react-router-dom'
+import { API_URL } from '../config'
 
 function Get() {
   const [users, setUsers] = useState([])
@@ -9,7 +10,7 @@ function Get() {
   const location = useLocation()
 
   useEffect(() => {
-    fetch('http://localhost:5000/users')
+    fetch(`${API_URL}/users`)
       .then((res) => res.json())
       .then((data) => setUsers(data))
       .catch((err) => console.error('Error:', err))
@@ -27,7 +28,7 @@ function Get() {
     if (!userToDelete) return
     try {
       const res = await fetch(
-        `http://localhost:5000/users/${userToDelete.id}`,
+        `${API_URL}/users/${userToDelete.id}`,
         {
           method: 'DELETE'
         }

--- a/WebsiteAdmin/src/authPage/AuthPage.jsx
+++ b/WebsiteAdmin/src/authPage/AuthPage.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import axios from 'axios'
+import { API_URL } from '../config'
 
 const AuthPage = ({ setIsAuthenticated, setAuthToken }) => {
   const [username, setUsername] = useState('')
@@ -12,7 +13,7 @@ const AuthPage = ({ setIsAuthenticated, setAuthToken }) => {
     e.preventDefault()
 
     try {
-      const response = await axios.post('http://localhost:5000/admins/login', {
+      const response = await axios.post(`${API_URL}/admins/login`, {
         username,
         password
       })

--- a/WebsiteAdmin/src/booking/Create.jsx
+++ b/WebsiteAdmin/src/booking/Create.jsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
+import { API_URL } from '../config'
 function Create() {
   const [userId, setUserId] = useState('')
   const [salonId, setSalonId] = useState('')
@@ -11,7 +12,7 @@ function Create() {
   const handleSubmit = async (e) => {
     e.preventDefault()
     try {
-      const res = await fetch('http://localhost:5000/bookings', {
+      const res = await fetch(`${API_URL}/bookings`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json'

--- a/WebsiteAdmin/src/booking/Edit.jsx
+++ b/WebsiteAdmin/src/booking/Edit.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
+import { API_URL } from '../config'
 
 function Edit() {
   const [userId, setUserId] = useState('')
@@ -13,7 +14,7 @@ function Edit() {
   useEffect(() => {
     const fetchBooking = async () => {
       try {
-        const res = await fetch(`http://localhost:5000/bookings/${id}`)
+        const res = await fetch(`${API_URL}/bookings/${id}`)
         const data = await res.json()
         if (res.ok) {
           setUserId(data.user_id)
@@ -36,7 +37,7 @@ function Edit() {
   const handleSubmit = async (e) => {
     e.preventDefault()
     try {
-      const res = await fetch(`http://localhost:5000/bookings/${id}`, {
+      const res = await fetch(`${API_URL}/bookings/${id}`, {
         method: 'PUT',
         headers: {
           'Content-Type': 'application/json'

--- a/WebsiteAdmin/src/booking/Get.jsx
+++ b/WebsiteAdmin/src/booking/Get.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import { useNavigate, useLocation, Link } from 'react-router-dom'
+import { API_URL } from '../config'
 
 function Get() {
   const [bookings, setBookings] = useState([])
@@ -9,7 +10,7 @@ function Get() {
   const location = useLocation()
 
   useEffect(() => {
-    fetch('http://localhost:5000/bookings')
+    fetch(`${API_URL}/bookings`)
       .then((res) => res.json())
       .then((data) => setBookings(data))
       .catch((err) => console.error('Error fetching bookings:', err))
@@ -27,7 +28,7 @@ function Get() {
     if (!bookingToDelete) return
     try {
       const res = await fetch(
-        `http://localhost:5000/bookings/${bookingToDelete.id}`,
+        `${API_URL}/bookings/${bookingToDelete.id}`,
         {
           method: 'DELETE'
         }

--- a/WebsiteAdmin/src/components/Sidebar.jsx
+++ b/WebsiteAdmin/src/components/Sidebar.jsx
@@ -13,6 +13,7 @@ import {
   FaTags
 } from 'react-icons/fa'
 import axios from 'axios'
+import { API_URL } from '../config'
 
 const Sidebar = () => {
   const [active, setActive] = useState('User Management')
@@ -35,7 +36,7 @@ const Sidebar = () => {
     const token = localStorage.getItem('authToken')
     try {
       await axios.post(
-        'http://localhost:5000/admins/logout',
+        `${API_URL}/admins/logout`,
         {},
         {
           headers: { Authorization: `Bearer ${token}` }

--- a/WebsiteAdmin/src/config.js
+++ b/WebsiteAdmin/src/config.js
@@ -1,0 +1,2 @@
+export const API_URL = import.meta.env.VITE_API_URL;
+export const APP_URL = import.meta.env.VITE_APP_URL;

--- a/WebsiteAdmin/src/contact.js/Get.jsx
+++ b/WebsiteAdmin/src/contact.js/Get.jsx
@@ -1,10 +1,11 @@
 import { useEffect, useState } from 'react'
+import { API_URL } from '../config'
 
 function Get() {
   const [contacts, setContacts] = useState([])
 
   useEffect(() => {
-    fetch('http://localhost:5000/contacts')
+    fetch(`${API_URL}/contacts`)
       .then((res) => res.json())
       .then((data) => {
         setContacts(data)

--- a/WebsiteAdmin/src/package/Create.jsx
+++ b/WebsiteAdmin/src/package/Create.jsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
+import { API_URL } from '../config'
 
 function Create() {
   const [title, setTitle] = useState('')
@@ -30,7 +31,7 @@ function Create() {
     if (image) formData.append('image', image)
 
     try {
-      const res = await fetch('http://localhost:5000/package', {
+      const res = await fetch(`${API_URL}/package`, {
         method: 'POST',
         body: formData
       })

--- a/WebsiteAdmin/src/package/Edit.jsx
+++ b/WebsiteAdmin/src/package/Edit.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
+import { API_URL } from '../config'
 
 function EditPackage() {
   const [title, setTitle] = useState('')
@@ -15,7 +16,7 @@ function EditPackage() {
 
   useEffect(() => {
     const fetchPackage = async () => {
-      const res = await fetch(`http://localhost:5000/package/${id}`)
+      const res = await fetch(`${API_URL}/package/${id}`)
       const data = await res.json()
       if (res.ok) {
         setTitle(data.title)
@@ -45,7 +46,7 @@ function EditPackage() {
       formData.append('image', newImage)
     }
 
-    const res = await fetch(`http://localhost:5000/package/${id}`, {
+    const res = await fetch(`${API_URL}/package/${id}`, {
       method: 'PUT',
       body: formData
     })

--- a/WebsiteAdmin/src/package/Get.jsx
+++ b/WebsiteAdmin/src/package/Get.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import { useNavigate, Link } from 'react-router-dom'
+import { API_URL } from '../config'
 
 function Get() {
   const [packages, setPackages] = useState([])
@@ -8,7 +9,7 @@ function Get() {
   const navigate = useNavigate()
 
   useEffect(() => {
-    fetch('http://localhost:5000/package')
+    fetch(`${API_URL}/package`)
       .then((res) => res.json())
       .then((data) => setPackages(data))
       .catch((err) => console.error('Error:', err))
@@ -23,7 +24,7 @@ function Get() {
 
     try {
       const res = await fetch(
-        `http://localhost:5000/package/${packageToDelete.id}`,
+        `${API_URL}/package/${packageToDelete.id}`,
         {
           method: 'DELETE'
         }

--- a/WebsiteAdmin/src/product/Create.jsx
+++ b/WebsiteAdmin/src/product/Create.jsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
+import { API_URL } from '../config'
 
 function Create() {
   const [name, setName] = useState('')
@@ -38,7 +39,7 @@ function Create() {
     if (image) formData.append('image', image)
 
     try {
-      const res = await fetch('http://localhost:5000/product', {
+      const res = await fetch(`${API_URL}/product`, {
         method: 'POST',
         body: formData
       })

--- a/WebsiteAdmin/src/product/Edit.jsx
+++ b/WebsiteAdmin/src/product/Edit.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
+import { API_URL } from '../config'
 
 function Edit() {
   const [name, setName] = useState('')
@@ -16,7 +17,7 @@ function Edit() {
   useEffect(() => {
     const fetchProduct = async () => {
       try {
-        const res = await fetch(`http://localhost:5000/product/${id}`)
+        const res = await fetch(`${API_URL}/product/${id}`)
         const data = await res.json()
 
         if (res.ok) {
@@ -51,7 +52,7 @@ function Edit() {
     }
 
     try {
-      const res = await fetch(`http://localhost:5000/product/${id}`, {
+      const res = await fetch(`${API_URL}/product/${id}`, {
         method: 'PUT',
         body: formData
       })

--- a/WebsiteAdmin/src/product/Get.jsx
+++ b/WebsiteAdmin/src/product/Get.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import { useNavigate, Link } from 'react-router-dom'
+import { API_URL } from '../config'
 
 function Get() {
   const [products, setProducts] = useState([])
@@ -8,7 +9,7 @@ function Get() {
   const navigate = useNavigate()
 
   useEffect(() => {
-    fetch('http://localhost:5000/product')
+    fetch(`${API_URL}/product`)
       .then((res) => res.json())
       .then((data) => {
         setProducts(data)
@@ -26,7 +27,7 @@ function Get() {
 
     try {
       const res = await fetch(
-        `http://localhost:5000/product/${productToDelete.id}`,
+        `${API_URL}/product/${productToDelete.id}`,
         {
           method: 'DELETE'
         }

--- a/WebsiteAdmin/src/types/Create.jsx
+++ b/WebsiteAdmin/src/types/Create.jsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
+import { API_URL } from '../config'
 
 function Create() {
   const [typeName, setTypeName] = useState('')
@@ -24,7 +25,7 @@ function Create() {
     if (image) formData.append('image', image)
 
     try {
-      const res = await fetch('http://localhost:5000/types', {
+      const res = await fetch(`${API_URL}/types`, {
         method: 'POST',
         body: formData
       })

--- a/WebsiteAdmin/src/types/Edit.jsx
+++ b/WebsiteAdmin/src/types/Edit.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
+import { API_URL } from '../config'
 
 function Edit() {
   const [typeName, setTypeName] = useState('')
@@ -10,7 +11,7 @@ function Edit() {
   useEffect(() => {
     const fetchType = async () => {
       try {
-        const res = await fetch(`http://localhost:5000/types/${id}`)
+        const res = await fetch(`${API_URL}/types/${id}`)
         const data = await res.json()
 
         if (res.ok) {
@@ -38,7 +39,7 @@ function Edit() {
     if (image) formData.append('image', image)
 
     try {
-      const res = await fetch(`http://localhost:5000/types/${id}`, {
+      const res = await fetch(`${API_URL}/types/${id}`, {
         method: 'PUT',
         body: formData
       })
@@ -80,7 +81,7 @@ function Edit() {
           {image && (
             <div className="mt-2">
               <img
-                src={`http://localhost:5000/${image}`}
+                src={`${API_URL}/${image}`}
                 alt="Current type"
                 width="100"
                 height="100"

--- a/WebsiteAdmin/src/types/Get.jsx
+++ b/WebsiteAdmin/src/types/Get.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import { useNavigate, Link } from 'react-router-dom'
+import { API_URL } from '../config'
 
 function Get() {
   const [types, setTypes] = useState([])
@@ -8,7 +9,7 @@ function Get() {
   const navigate = useNavigate()
 
   useEffect(() => {
-    fetch('http://localhost:5000/types') // Make sure your backend is running at this URL
+    fetch(`${API_URL}/types`) // Make sure your backend is running at this URL
       .then((res) => res.json())
       .then((data) => {
         setTypes(data)
@@ -25,7 +26,7 @@ function Get() {
 
     try {
       const res = await fetch(
-        `http://localhost:5000/types/${typeToDelete.id}`,
+        `${API_URL}/types/${typeToDelete.id}`,
         {
           method: 'DELETE'
         }

--- a/WebsiteSalon/.env.example
+++ b/WebsiteSalon/.env.example
@@ -1,0 +1,2 @@
+VITE_API_URL=http://localhost:5000
+VITE_APP_URL=http://localhost:3000

--- a/WebsiteSalon/src/config.js
+++ b/WebsiteSalon/src/config.js
@@ -1,0 +1,2 @@
+export const API_URL = import.meta.env.VITE_API_URL;
+export const APP_URL = import.meta.env.VITE_APP_URL;

--- a/WebsiteSalon/src/pages/Bookings.jsx
+++ b/WebsiteSalon/src/pages/Bookings.jsx
@@ -2,13 +2,14 @@ import React, { useEffect, useState } from 'react'
 import axios from 'axios'
 import { useAuth } from '../context/AuthContext'
 import Navbar from '../components/Navbar'
+import { API_URL } from '../config'
 
 export default function BookingsPage() {
   const [bookings, setBookings] = useState([])
   const { auth } = useAuth()
 
   const fetchBookings = () => {
-    axios.get('http://localhost:5000/bookings').then((res) => {
+    axios.get(`${API_URL}/bookings`).then((res) => {
       const filtered = res.data
         .filter((b) => b.salon_name === auth.name)
         .sort((a, b) => {
@@ -49,7 +50,7 @@ export default function BookingsPage() {
 
   const markAsCompleted = async (id) => {
     try {
-      await axios.put(`http://localhost:5000/bookings/${id}`, {
+      await axios.put(`${API_URL}/bookings/${id}`, {
         status: 'completed'
       })
       fetchBookings()

--- a/WebsiteSalon/src/pages/Dashboard.jsx
+++ b/WebsiteSalon/src/pages/Dashboard.jsx
@@ -14,6 +14,7 @@ import {
 import axios from 'axios'
 import { useAuth } from '../context/AuthContext'
 import Navbar from '../components/Navbar'
+import { API_URL } from '../config'
 
 ChartJS.register(
   BarElement,
@@ -31,7 +32,7 @@ export default function DashboardPage() {
   const { auth } = useAuth()
 
   useEffect(() => {
-    axios.get('http://localhost:5000/bookings').then((res) => {
+    axios.get(`${API_URL}/bookings`).then((res) => {
       const filtered = res.data.filter((b) => b.salon_name === auth.name)
       setBookings(filtered)
     })

--- a/WebsiteSalon/src/pages/Login.jsx
+++ b/WebsiteSalon/src/pages/Login.jsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useAuth } from '../context/AuthContext'
 import axios from 'axios'
+import { API_URL } from '../config'
 
 export default function Login() {
   const [email, setEmail] = useState('')
@@ -12,12 +13,12 @@ export default function Login() {
   const handleLogin = async (e) => {
     e.preventDefault()
     try {
-      const res = await axios.post('http://localhost:5000/salons/login', {
+      const res = await axios.post(`${API_URL}/salons/login`, {
         email,
         password
       })
       const token = res.data.token
-      const profile = await axios.get('http://localhost:5000/salons/me', {
+      const profile = await axios.get(`${API_URL}/salons/me`, {
         headers: { Authorization: `Bearer ${token}` }
       })
       setAuth({ ...profile.data, token })

--- a/WebsiteSalon/src/pages/SignupStep2.jsx
+++ b/WebsiteSalon/src/pages/SignupStep2.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
 import axios from 'axios'
+import { API_URL } from '../config'
 
 function SignupStep2() {
   const [name, setName] = useState('')
@@ -11,9 +12,9 @@ function SignupStep2() {
   const navigate = useNavigate()
 
   useEffect(() => {
-    axios.get('http://localhost:5000/types').then((res) => setTypes(res.data))
+    axios.get(`${API_URL}/types`).then((res) => setTypes(res.data))
     axios
-      .get('http://localhost:5000/services')
+      .get(`${API_URL}/services`)
       .then((res) => setServices(res.data))
   }, [])
 

--- a/WebsiteSalon/src/pages/SignupStep3.jsx
+++ b/WebsiteSalon/src/pages/SignupStep3.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import axios from 'axios'
+import { API_URL } from '../config'
 import { MapContainer, TileLayer, Marker, useMapEvents } from 'react-leaflet'
 import 'leaflet/dist/leaflet.css'
 import L from 'leaflet'
@@ -64,20 +65,20 @@ function SignupStep3() {
 
     try {
       const res = await axios.post(
-        'http://localhost:5000/salons/register',
+        `${API_URL}/salons/register`,
         formData,
         {
           headers: { 'Content-Type': 'multipart/form-data' }
         }
       )
 
-      await axios.post('http://localhost:5000/types/assign', {
+      await axios.post(`${API_URL}/types/assign`, {
         salonId: res.data.salon.id,
         typeIds: step2.selectedTypes
       })
 
       await axios.post(
-        `http://localhost:5000/services/salon/${res.data.salon.id}`,
+        `${API_URL}/services/salon/${res.data.salon.id}`,
         {
           serviceIds: step2.selectedServices
         }

--- a/WebsiteUser/.env.example
+++ b/WebsiteUser/.env.example
@@ -1,0 +1,2 @@
+VITE_API_URL=http://localhost:5000
+VITE_APP_URL=http://localhost:3000

--- a/WebsiteUser/src/components/orders/OrderDetailsPage.jsx
+++ b/WebsiteUser/src/components/orders/OrderDetailsPage.jsx
@@ -3,6 +3,7 @@ import { useParams, useLocation } from 'react-router-dom'
 import { Helmet } from 'react-helmet'
 import styled from 'styled-components'
 import { useTranslation } from 'react-i18next'
+import { API_URL } from '../../config'
 import useFetch from '../../hooks/useFetch'
 
 const Container = styled.div`
@@ -105,7 +106,7 @@ const OrderDetailsPage = () => {
     state?.order
       ? null
       : id
-      ? `http://localhost:5000/orders/order/${id}`
+      ? `${API_URL}/orders/order/${id}`
       : null,
     [id]
   )
@@ -128,7 +129,7 @@ const OrderDetailsPage = () => {
   const handleCancelOrder = async () => {
     try {
       const res = await fetch(
-        `http://localhost:5000/orders/order/${id}/cancel`,
+        `${API_URL}/orders/order/${id}/cancel`,
         { method: 'PATCH' }
       )
       if (!res.ok) throw new Error(`HTTP error ${res.status}`)

--- a/WebsiteUser/src/config.js
+++ b/WebsiteUser/src/config.js
@@ -1,0 +1,2 @@
+export const API_URL = import.meta.env.VITE_API_URL;
+export const APP_URL = import.meta.env.VITE_APP_URL;

--- a/WebsiteUser/src/functionality/auth/UseChangePassword.jsx
+++ b/WebsiteUser/src/functionality/auth/UseChangePassword.jsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import axios from 'axios'
 import { useTranslation } from 'react-i18next'
+import { API_URL } from '../../config'
 
 const useChangePassword = ({ userId }) => {
   const { t } = useTranslation()
@@ -36,7 +37,7 @@ const useChangePassword = ({ userId }) => {
 
     setLoading(true)
     try {
-      await axios.put(`http://localhost:5000/users/${userId}/change-password`, {
+      await axios.put(`${API_URL}/users/${userId}/change-password`, {
         currentPassword,
         newPassword
       })

--- a/WebsiteUser/src/functionality/auth/UseEditProfile.jsx
+++ b/WebsiteUser/src/functionality/auth/UseEditProfile.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react'
 import axios from 'axios'
 import { useTranslation } from 'react-i18next'
+import { API_URL } from '../../config'
 
 const useEditProfile = ({ userId }) => {
   const { t } = useTranslation()
@@ -18,7 +19,7 @@ const useEditProfile = ({ userId }) => {
       setError('')
       setSuccess('')
       try {
-        const res = await axios.get(`http://localhost:5000/users/${userId}`)
+        const res = await axios.get(`${API_URL}/users/${userId}`)
         setFormData({
           username: res.data.username || '',
           email: res.data.email || ''
@@ -49,7 +50,7 @@ const useEditProfile = ({ userId }) => {
     }
 
     try {
-      await axios.put(`http://localhost:5000/users/${userId}`, formData)
+      await axios.put(`${API_URL}/users/${userId}`, formData)
       setSuccess(t('Profile updated successfully!'))
     } catch (err) {
       setError(err.response?.data?.message || t('Failed to update profile'))

--- a/WebsiteUser/src/functionality/auth/UseSignIn.jsx
+++ b/WebsiteUser/src/functionality/auth/UseSignIn.jsx
@@ -12,7 +12,7 @@ const useSignIn = ({ setUser }) => {
 
   const handleSignIn = async () => {
     try {
-      const res = await fetch('http://localhost:5000/users/login', {
+      const res = await fetch(`${import.meta.env.VITE_API_URL}/users/login`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ username, password })

--- a/WebsiteUser/src/functionality/auth/UseSignUp.jsx
+++ b/WebsiteUser/src/functionality/auth/UseSignUp.jsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
+import { API_URL } from '../../config'
 
 const useSignUp = () => {
   const navigate = useNavigate()
@@ -24,7 +25,7 @@ const useSignUp = () => {
     }
 
     try {
-      const res = await fetch('http://localhost:5000/users/register', {
+      const res = await fetch(`${API_URL}/users/register`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ email, username, password })

--- a/WebsiteUser/src/functionality/cart/UseCart.jsx
+++ b/WebsiteUser/src/functionality/cart/UseCart.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
 import axios from 'axios'
 import { useTranslation } from 'react-i18next'
+import { API_URL } from '../../config'
 
 const useCart = () => {
   const { t } = useTranslation()
@@ -35,7 +36,7 @@ const useCart = () => {
       updated.splice(index, 1)
       updateCartStorage(updated)
       try {
-        await axios.patch(`http://localhost:5000/${type}/${id}/increase`)
+        await axios.patch(`${API_URL}/${type}/${id}/increase`)
       } catch (err) {
         console.error('Failed to restore quantity', err)
       }
@@ -51,7 +52,7 @@ const useCart = () => {
 
     try {
       for (let i = 0; i < quantityToRestore; i++) {
-        await axios.patch(`http://localhost:5000/${type}/${id}/increase`)
+        await axios.patch(`${API_URL}/${type}/${id}/increase`)
       }
     } catch (err) {
       console.error('Failed to restore quantity for removed item', err)

--- a/WebsiteUser/src/functionality/cart/UseCheckout.jsx
+++ b/WebsiteUser/src/functionality/cart/UseCheckout.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import axios from 'axios'
+import { API_URL, APP_URL } from '../../config'
 
 const useCheckout = () => {
   const { t } = useTranslation()
@@ -60,14 +61,13 @@ const useCheckout = () => {
       const query = new URLSearchParams({
         amount: total.toFixed(2),
         orderId: 'mock123456',
-        'response-url':
-          'http://localhost:3000/payment-success?redirect=bookings'
+        'response-url': `${APP_URL}/payment-success?redirect=bookings`
       }).toString()
 
       window.location.href = `https://mock-benefit-gateway.com/pay?${query}`
     } else {
       try {
-        await axios.post('http://localhost:5000/orders', orderPayload)
+        await axios.post(`${API_URL}/orders`, orderPayload)
         setSuccessMsg(true)
         setTimeout(() => {
           localStorage.removeItem('cart')

--- a/WebsiteUser/src/functionality/layout/UseNavbar.jsx
+++ b/WebsiteUser/src/functionality/layout/UseNavbar.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import { useNavigate, useLocation } from 'react-router-dom'
 import axios from 'axios'
 import { useTranslation } from 'react-i18next'
+import { API_URL } from '../../config'
 
 const useNavbar = ({ userType, setUser }) => {
   const { t, i18n } = useTranslation()
@@ -13,7 +14,7 @@ const useNavbar = ({ userType, setUser }) => {
 
   useEffect(() => {
     axios
-      .get('http://localhost:5000/types')
+      .get(`${API_URL}/types`)
       .then((res) => {
         setTypes(res.data)
         const selected = res.data.find((t) => t.type_name === userType)

--- a/WebsiteUser/src/functionality/orders/UseBookingDetails.jsx
+++ b/WebsiteUser/src/functionality/orders/UseBookingDetails.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react'
 import useFetch from '../../hooks/useFetch'
+import { API_URL } from '../../config'
 
 const useBookingDetails = (id, t) => {
   const [cancelError, setCancelError] = useState(null)
@@ -8,7 +9,7 @@ const useBookingDetails = (id, t) => {
     data: bookingData,
     loading,
     error
-  } = useFetch(`http://localhost:5000/bookings/${id}`, [id])
+  } = useFetch(`${API_URL}/bookings/${id}`, [id])
 
   const [booking, setBooking] = useState(null)
 
@@ -31,7 +32,7 @@ const useBookingDetails = (id, t) => {
   const handleCancelBooking = async () => {
     setCancelError(null)
     try {
-      const res = await fetch(`http://localhost:5000/bookings/${id}/cancel`, {
+      const res = await fetch(`${API_URL}/bookings/${id}/cancel`, {
         method: 'PATCH'
       })
       if (!res.ok) throw new Error(`HTTP error ${res.status}`)

--- a/WebsiteUser/src/functionality/orders/UseMyBookings.jsx
+++ b/WebsiteUser/src/functionality/orders/UseMyBookings.jsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import useFetch from '../../hooks/useFetch'
+import { API_URL } from '../../config'
 
 const useMyBookings = (t, user) => {
   const [showFilters, setShowFilters] = useState(false)
@@ -11,13 +12,13 @@ const useMyBookings = (t, user) => {
     data: bookingsData = [],
     loading: bookingsLoading,
     error: bookingsError
-  } = useFetch(user?.id ? 'http://localhost:5000/bookings' : null, [user?.id])
+  } = useFetch(user?.id ? `${API_URL}/bookings` : null, [user?.id])
 
   const {
     data: ordersData = [],
     loading: ordersLoading,
     error: ordersError
-  } = useFetch(user?.id ? `http://localhost:5000/orders/${user.id}` : null, [
+  } = useFetch(user?.id ? `${API_URL}/orders/${user.id}` : null, [
     user?.id
   ])
   const bookingsArray = Array.isArray(bookingsData) ? bookingsData : []
@@ -110,7 +111,7 @@ const useMyBookings = (t, user) => {
     if (!id) return
     try {
       const response = await fetch(
-        `http://localhost:5000/bookings/${id}/cancel`,
+        `${API_URL}/bookings/${id}/cancel`,
         {
           method: 'PATCH'
         }
@@ -130,7 +131,7 @@ const useMyBookings = (t, user) => {
   const handleRequestCancelOrder = async (orderId, setOrders) => {
     if (!orderId) return
     try {
-      const response = await fetch(`http://localhost:5000/orders/${orderId}`, {
+      const response = await fetch(`${API_URL}/orders/${orderId}`, {
         method: 'DELETE'
       })
       if (response.ok) {

--- a/WebsiteUser/src/functionality/orders/UseSalonBooking.jsx
+++ b/WebsiteUser/src/functionality/orders/UseSalonBooking.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useMemo } from 'react'
 import axios from 'axios'
 import moment from 'moment'
+import { API_URL } from '../../config'
 
 export const useSalonBooking = ({ salonId, userId, t, navigate }) => {
   const [salon, setSalon] = useState(null)
@@ -32,8 +33,8 @@ export const useSalonBooking = ({ salonId, userId, t, navigate }) => {
     const fetchSalonAndServices = async () => {
       try {
         const [salonRes, servicesRes] = await Promise.all([
-          axios.get(`http://localhost:5000/salons/${salonId}`),
-          axios.get(`http://localhost:5000/services/salon/${salonId}`)
+          axios.get(`${API_URL}/salons/${salonId}`),
+          axios.get(`${API_URL}/services/salon/${salonId}`)
         ])
         const salonData = salonRes.data
         const slots = generateTimeSlots(
@@ -58,7 +59,7 @@ export const useSalonBooking = ({ salonId, userId, t, navigate }) => {
     const fetchBookedSlots = async () => {
       try {
         const res = await axios.get(
-          `http://localhost:5000/bookings/${salonId}/${date}/slots`
+          `${API_URL}/bookings/${salonId}/${date}/slots`
         )
         setBookedSlots(res.data)
       } catch (err) {
@@ -141,7 +142,7 @@ export const useSalonBooking = ({ salonId, userId, t, navigate }) => {
     }
 
     try {
-      await axios.post(`http://localhost:5000/bookings`, {
+      await axios.post(`${API_URL}/bookings`, {
         user_id: userId,
         salon_id: salonId,
         service: selectedServices.join(','),

--- a/WebsiteUser/src/functionality/products/UseFavorites.jsx
+++ b/WebsiteUser/src/functionality/products/UseFavorites.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react'
+import { API_URL } from '../../config'
 
 export default function useFavorites(userId, userType) {
   const [userLocation, setUserLocation] = useState(null)
@@ -26,7 +27,7 @@ export default function useFavorites(userId, userType) {
       setLoading(true)
       try {
         const res = await fetch(
-          `http://localhost:5000/favorites/${userId}?type=${userType}`
+          `${API_URL}/favorites/${userId}?type=${userType}`
         )
         const data = await res.json()
         const array = Array.isArray(data) ? data : []
@@ -68,7 +69,7 @@ export default function useFavorites(userId, userType) {
   const toggleFavorite = async (salonId) => {
     try {
       await fetch(
-        `http://localhost:5000/favorites/users/${userId}/favorites/${salonId}`,
+        `${API_URL}/favorites/users/${userId}/favorites/${salonId}`,
         { method: 'POST' }
       )
       // re-fetch updated favorites

--- a/WebsiteUser/src/functionality/products/UsePackages.jsx
+++ b/WebsiteUser/src/functionality/products/UsePackages.jsx
@@ -3,13 +3,14 @@
 import { useState, useEffect } from 'react'
 import axios from 'axios'
 import useFetch from '../../hooks/useFetch'
+import { API_URL } from '../../config'
 
 export default function usePackages(t) {
   const {
     data: fetchedPackages = [],
     loading,
     error
-  } = useFetch('http://localhost:5000/package', [])
+  } = useFetch(`${API_URL}/package`, [])
 
   const [packages, setPackages] = useState([])
   const [sortOption, setSortOption] = useState('')
@@ -67,7 +68,7 @@ export default function usePackages(t) {
     localStorage.setItem('cart', JSON.stringify([...cart, ...itemsToAdd]))
 
     try {
-      await axios.patch(`http://localhost:5000/package/${pack.id}/decrease`, {
+      await axios.patch(`${API_URL}/package/${pack.id}/decrease`, {
         qty
       })
       setPackages((prev) =>

--- a/WebsiteUser/src/functionality/products/UseProducts.jsx
+++ b/WebsiteUser/src/functionality/products/UseProducts.jsx
@@ -1,12 +1,13 @@
 import { useState, useEffect } from 'react'
 import useFetch from '../../hooks/useFetch'
+import { API_URL } from '../../config'
 
 export default function useProducts(t) {
   const {
     data: fetchedProducts = [],
     loading,
     error
-  } = useFetch('http://localhost:5000/product', [])
+  } = useFetch(`${API_URL}/product`, [])
 
   const [products, setProducts] = useState([])
   const [sortOption, setSortOption] = useState('')
@@ -64,7 +65,7 @@ export default function useProducts(t) {
     localStorage.setItem('cart', JSON.stringify([...cart, ...itemsToAdd]))
 
     try {
-      await fetch(`http://localhost:5000/product/${product.id}/decrease`, {
+      await fetch(`${API_URL}/product/${product.id}/decrease`, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ qty })

--- a/WebsiteUser/src/functionality/salons/UseSalonDetails.jsx
+++ b/WebsiteUser/src/functionality/salons/UseSalonDetails.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react'
 import useFetch from '../../hooks/useFetch'
+import { API_URL } from '../../config'
 
 export default function useSalonDetails(id) {
   const [isMobile, setIsMobile] = useState(window.innerWidth < 768)
@@ -15,7 +16,7 @@ export default function useSalonDetails(id) {
     data: salon,
     loading,
     error
-  } = useFetch(id ? `http://localhost:5000/salons/${id}` : null, [id])
+  } = useFetch(id ? `${API_URL}/salons/${id}` : null, [id])
 
   const latitude =
     salon?.latitude || salon?.location?.latitude || salon?.location?.lat

--- a/WebsiteUser/src/functionality/salons/useNearestSalons.jsx
+++ b/WebsiteUser/src/functionality/salons/useNearestSalons.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react'
 import useFetch from '../../hooks/useFetch'
+import { API_URL } from '../../config'
 
 export default function useNearestSalons(userType, userId) {
   const [userLocation, setUserLocation] = useState(null)
@@ -33,7 +34,7 @@ export default function useNearestSalons(userType, userId) {
     refetch
   } = useFetch(
     userLocation
-      ? `http://localhost:5000/salons?userLat=${userLocation.latitude}&userLng=${userLocation.longitude}&type=${userType}`
+      ? `${API_URL}/salons?userLat=${userLocation.latitude}&userLng=${userLocation.longitude}&type=${userType}`
       : null,
     [userLocation, userType]
   )
@@ -70,7 +71,7 @@ export default function useNearestSalons(userType, userId) {
     const fetchFavorites = async () => {
       if (!userId) return
       try {
-        const res = await fetch(`http://localhost:5000/favorites/${userId}`)
+        const res = await fetch(`${API_URL}/favorites/${userId}`)
         const data = await res.json()
         setFavorites(new Set(data.map((f) => Number(f.salon_id))))
       } catch (err) {
@@ -84,7 +85,7 @@ export default function useNearestSalons(userType, userId) {
   const toggleFavorite = async (salonId) => {
     try {
       await fetch(
-        `http://localhost:5000/favorites/users/${userId}/favorites/${salonId}`,
+        `${API_URL}/favorites/users/${userId}/favorites/${salonId}`,
         { method: 'POST' }
       )
       refetch()


### PR DESCRIPTION
## Summary
- replace hard-coded API addresses with `import.meta.env` variables
- add `config.js` helpers for API and app URLs
- provide `.env.example` files for all front-ends

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_687a1ccc5a308327af7534e2f739ce69