### PR TITLE
Add Jest tests for backend endpoints

### DIFF
--- a/ExpressBackend/package.json
+++ b/ExpressBackend/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "main": "server.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "jest",
     "start": "node server.js",
     "nodemon": "nodemon server.js"
   },
@@ -28,5 +28,9 @@
     "pg": "^8.15.6",
     "sequelize": "^6.37.7",
     "uuid": "^11.1.0"
+  },
+  "devDependencies": {
+    "jest": "^30.0.4",
+    "supertest": "^7.1.3"
   }
 }

--- a/ExpressBackend/server.js
+++ b/ExpressBackend/server.js
@@ -37,6 +37,11 @@ app.use('/cart', cartRouter)
 app.use('/orders', orderRouter)
 
 //server execute
-app.listen(5000, () => {
-  console.log(`server running on port 5000`)
-})
+if (require.main === module) {
+  const PORT = process.env.PORT || 5000
+  app.listen(PORT, () => {
+    console.log(`server running on port ${PORT}`)
+  })
+}
+
+module.exports = app

--- a/ExpressBackend/tests/auth.test.js
+++ b/ExpressBackend/tests/auth.test.js
@@ -1,0 +1,44 @@
+const request = require('supertest')
+
+jest.mock('bcrypt', () => ({
+  hash: jest.fn(() => Promise.resolve('hashed')),
+  compare: jest.fn(() => Promise.resolve(true))
+}))
+const bcrypt = require('bcrypt')
+
+const mockQuery = jest.fn()
+jest.mock('../models/pool', () => ({ query: mockQuery }))
+
+const app = require('../server')
+
+describe('Authentication endpoints', () => {
+  beforeEach(() => {
+    mockQuery.mockReset()
+  })
+
+  test('registers a user', async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 })
+      .mockResolvedValueOnce({ rows: [{ id: 1, username: 'john', email: 'john@example.com' }] })
+
+    const res = await request(app)
+      .post('/users/register')
+      .send({ username: 'john', email: 'john@example.com', password: 'secret' })
+
+    expect(res.status).toBe(201)
+    expect(res.body.user).toEqual({ id: 1, username: 'john', email: 'john@example.com' })
+  })
+
+  test('logs in a user', async () => {
+    const hash = await bcrypt.hash('secret', 10)
+    mockQuery.mockResolvedValueOnce({ rows: [{ id: 1, username: 'john', password: hash }] })
+
+    const res = await request(app)
+      .post('/users/login')
+      .send({ username: 'john', password: 'secret' })
+
+    expect(res.status).toBe(200)
+    expect(res.body.message).toBe('Login successful')
+    expect(res.body).toHaveProperty('token')
+  })
+})

--- a/ExpressBackend/tests/booking.test.js
+++ b/ExpressBackend/tests/booking.test.js
@@ -1,0 +1,48 @@
+const request = require('supertest')
+
+jest.mock('bcrypt', () => ({
+  hash: jest.fn(() => Promise.resolve('hashed')),
+  compare: jest.fn(() => Promise.resolve(true))
+}))
+const bcrypt = require('bcrypt')
+
+const mockQuery = jest.fn()
+jest.mock('../models/pool', () => ({ query: mockQuery }))
+
+const app = require('../server')
+
+describe('Booking endpoints', () => {
+  beforeEach(() => {
+    mockQuery.mockReset()
+  })
+
+  test('lists bookings', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ id: 1 }], rowCount: 1 })
+
+    const res = await request(app).get('/bookings')
+
+    expect(res.status).toBe(200)
+    expect(Array.isArray(res.body)).toBe(true)
+    expect(res.body.length).toBe(1)
+  })
+
+  test('creates booking', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ id: 1 }], rowCount: 1 })
+
+    const res = await request(app)
+      .post('/bookings')
+      .send({
+        user_id: 1,
+        salon_id: 1,
+        service: '1',
+        booking_date: '2024-01-01',
+        booking_time: '12:00',
+        amount: 10,
+        duration: 30,
+        notes: ''
+      })
+
+    expect(res.status).toBe(201)
+    expect(res.body).toEqual({ id: 1 })
+  })
+})


### PR DESCRIPTION
## Summary
- export `app` from backend server to support testing
- add `jest` and `supertest` dev dependencies and update test script
- create tests for authentication and booking routes

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687b99f307708327b8b031f4ad001944