### PR TITLE
Highlight active sidebar item

### DIFF
--- a/WebsiteAdmin/src/components/Sidebar.jsx
+++ b/WebsiteAdmin/src/components/Sidebar.jsx
@@ -20,7 +20,10 @@ const Sidebar = () => {
   const location = useLocation()
 
   const navItem = (label, icon, route) => {
-    const isActive = location.pathname === route
+    // Highlight the sidebar entry when the current path starts with the
+    // navigation route. This ensures that nested routes such as edit or
+    // create pages still highlight the parent section.
+    const isActive = location.pathname.startsWith(route)
     return (
       <div
         className={`sidebar-item ${isActive ? 'active' : ''}`}


### PR DESCRIPTION
## Summary
- use `useLocation` to pull the current path
- apply an `active` class to the sidebar entry whose route matches the current location

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687ba6b806f08327b08792d741dcaf95