### PR TITLE
Add salon profile fetch by id

### DIFF
--- a/WebsiteSalon/src/pages/SalonProfile.jsx
+++ b/WebsiteSalon/src/pages/SalonProfile.jsx
@@ -13,9 +13,9 @@ export default function SalonProfile() {
   const [closingTime, setClosingTime] = useState('')
 
   useEffect(() => {
-    if (!auth?.token) return
+    if (!auth?.token || !auth?.id) return
     axios
-      .get(`${API_URL}/salons/me`, {
+      .get(`${API_URL}/salons/${auth.id}`, {
         headers: { Authorization: `Bearer ${auth.token}` }
       })
       .then((res) => {


### PR DESCRIPTION
## Summary
- use `/salons/:id` endpoint when fetching the salon profile

## Testing
- `npm run lint` in `WebsiteSalon`

------
https://chatgpt.com/codex/tasks/task_e_687ba6ba1c6c83278b64bda5d717fea1