### PR TITLE
Use env vars for server config

### DIFF
--- a/ExpressBackend/.env.example
+++ b/ExpressBackend/.env.example
@@ -1,0 +1,7 @@
+DB_USER=your_db_user
+DB_HOST=localhost
+DB_DATABASE=MySalons
+DB_PASSWORD=your_db_password
+DB_PORT=5432
+JWT_SECRET=your_jwt_secret
+PORT=5000

--- a/ExpressBackend/controllers/authAdmin.js
+++ b/ExpressBackend/controllers/authAdmin.js
@@ -2,7 +2,7 @@ const pool = require('../models/pool')
 const bcrypt = require('bcrypt')
 const jwt = require('jsonwebtoken')
 
-const JWT_SECRET = 'your_secret_key_here'
+const JWT_SECRET = process.env.JWT_SECRET
 
 const registerAdmin = async (req, res) => {
   const { username, password } = req.body

--- a/ExpressBackend/controllers/authSalon.js
+++ b/ExpressBackend/controllers/authSalon.js
@@ -3,7 +3,7 @@ const bcrypt = require('bcrypt')
 const jwt = require('jsonwebtoken')
 const uploadToAzure = require('../middleware/azureBlob')
 
-const JWT_SECRET = 'your_secret_key_here'
+const JWT_SECRET = process.env.JWT_SECRET
 
 const registerSalon = async (req, res) => {
   let location

--- a/ExpressBackend/controllers/authUser.js
+++ b/ExpressBackend/controllers/authUser.js
@@ -2,7 +2,7 @@ const pool = require('../models/pool')
 const bcrypt = require('bcrypt')
 const jwt = require('jsonwebtoken')
 
-const JWT_SECRET = 'your_secret_key_here'
+const JWT_SECRET = process.env.JWT_SECRET
 
 const registerUser = async (req, res) => {
   const { username, email, password } = req.body

--- a/ExpressBackend/models/pool.js
+++ b/ExpressBackend/models/pool.js
@@ -1,11 +1,12 @@
+require('dotenv').config()
 const { Pool } = require('pg')
 
 const pool = new Pool({
-  user: 'postgres',
-  host: 'localhost',
-  database: 'MySalons',
-  password: '38822164',
-  port: 5432
+  user: process.env.DB_USER,
+  host: process.env.DB_HOST,
+  database: process.env.DB_DATABASE,
+  password: process.env.DB_PASSWORD,
+  port: process.env.DB_PORT ? parseInt(process.env.DB_PORT, 10) : undefined
 })
 
 module.exports = pool


### PR DESCRIPTION
## Summary
- pull DB connection details from environment
- load JWT secret from environment in all auth controllers
- add example `.env`

## Testing
- `npm test --prefix ExpressBackend`

------
https://chatgpt.com/codex/tasks/task_e_687ba6bbd9d48327ba8c8fd2e2552c28