### PR TITLE
Add Jest tests for auth and booking

### DIFF
--- a/ExpressBackend/package.json
+++ b/ExpressBackend/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "main": "server.js",
   "scripts": {
-    "test": "jest",
+    "test": "jest --runInBand",
     "start": "node server.js",
     "nodemon": "nodemon server.js"
   },

--- a/ExpressBackend/tests/auth.test.js
+++ b/ExpressBackend/tests/auth.test.js
@@ -41,4 +41,16 @@ describe('Authentication endpoints', () => {
     expect(res.body.message).toBe('Login successful')
     expect(res.body).toHaveProperty('token')
   })
+
+  test('rejects invalid credentials', async () => {
+    const hash = await bcrypt.hash('secret', 10)
+    mockQuery.mockResolvedValueOnce({ rows: [{ id: 1, username: 'john', password: hash }] })
+    bcrypt.compare.mockResolvedValueOnce(false)
+
+    const res = await request(app)
+      .post('/users/login')
+      .send({ username: 'john', password: 'wrong' })
+
+    expect(res.status).toBe(401)
+  })
 })

--- a/ExpressBackend/tests/booking.test.js
+++ b/ExpressBackend/tests/booking.test.js
@@ -45,4 +45,14 @@ describe('Booking endpoints', () => {
     expect(res.status).toBe(201)
     expect(res.body).toEqual({ id: 1 })
   })
+
+  test('rejects booking with missing fields', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 })
+
+    const res = await request(app)
+      .post('/bookings')
+      .send({})
+
+    expect(res.status).toBe(400)
+  })
 })


### PR DESCRIPTION
## Summary
- expand Jest coverage for authentication and booking APIs
- add npm test script with `--runInBand`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687ba6c48d588327a0b687e074545369