### PR TITLE
Add express-validator for contact form

### DIFF
--- a/ExpressBackend/package.json
+++ b/ExpressBackend/package.json
@@ -21,6 +21,7 @@
     "cors": "^2.8.5",
     "dotenv": "^16.5.0",
     "express": "^4.21.2",
+    "express-validator": "^7.2.1",
     "jsonwebtoken": "^9.0.2",
     "multer": "^1.4.5-lts.2",
     "mysql2": "^3.14.1",

--- a/ExpressBackend/routes/contact.js
+++ b/ExpressBackend/routes/contact.js
@@ -1,8 +1,31 @@
 const express = require('express')
+const { body, validationResult } = require('express-validator')
+
 const router = express.Router()
 const { getContact, addContact } = require('../controllers/contact')
 
 router.get('/', getContact)
-router.post('/', addContact)
+
+router.post(
+  '/',
+  [
+    body('name').trim().notEmpty().withMessage('Name is required'),
+    body('email')
+      .trim()
+      .notEmpty()
+      .withMessage('Email is required')
+      .bail()
+      .isEmail()
+      .withMessage('Email is invalid')
+  ],
+  (req, res, next) => {
+    const errors = validationResult(req)
+    if (!errors.isEmpty()) {
+      return res.status(400).json({ errors: errors.array() })
+    }
+    next()
+  },
+  addContact
+)
 
 module.exports = router


### PR DESCRIPTION
## Summary
- add express-validator dependency
- validate name and email on contact form

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687ba6c888c48327bee969e2728635ec