### PR TITLE
Add morgan logging in development

### DIFF
--- a/ExpressBackend/server.js
+++ b/ExpressBackend/server.js
@@ -8,6 +8,12 @@ app.use(cors())
 app.use(bodyParser.json())
 app.use(express.json())
 
+// Log requests in development mode
+if (process.env.NODE_ENV === 'development') {
+  const morgan = require('morgan')
+  app.use(morgan('dev'))
+}
+
 //Routes
 const userAuthRoutes = require('./routes/authUser')
 const adminAuthRoutes = require('./routes/authAdmin')


### PR DESCRIPTION
## Summary
- log HTTP requests using morgan when `NODE_ENV` is `development`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687ba6caee3083278757f0e63b3c62af