### PR TITLE
Add Dockerfile for Express backend

### DIFF
--- a/ExpressBackend/Dockerfile
+++ b/ExpressBackend/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:18
+WORKDIR /usr/src/app
+COPY package*.json ./
+RUN npm install --production
+COPY . .
+EXPOSE 5000
+CMD ["node", "server.js"]

--- a/ExpressBackend/README.md
+++ b/ExpressBackend/README.md
@@ -1,0 +1,15 @@
+# Express Backend
+
+This directory contains the Express.js backend for MySalonApp.
+
+## Docker
+
+1. Build the Docker image from this folder:
+   ```sh
+   docker build -t express-backend .
+   ```
+2. Run the container and expose port 5000:
+   ```sh
+   docker run -p 5000:5000 express-backend
+   ```
+   Provide environment variables using `--env-file` or `-e` options if required.


### PR DESCRIPTION
## Summary
- add Dockerfile for Express backend
- document Docker build and run instructions

## Testing
- `npx -y jest` *(fails: Cannot find module 'supertest')*
- `npm install --no-save jest supertest`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687ba6d10e64832781ceae6f7c7b5c74