### PR TITLE
Add About and Contact translations

### DIFF
--- a/WebsiteUser/src/locales/ar/translation.json
+++ b/WebsiteUser/src/locales/ar/translation.json
@@ -211,5 +211,8 @@
   "Comment": "تعليق",
   "Enter your comment": "أدخل تعليقك",
   "Submit": "إرسال",
-  "Message sent successfully!": "تم إرسال الرسالة بنجاح!"
+  "Message sent successfully!": "تم إرسال الرسالة بنجاح!",
+  "MySalon connects you with trusted salons and stylists for quality beauty and grooming services.": "يربطك ماي صالون بصالونات ومصففي شعر موثوقين لخدمات تجميل وعناية عالية الجودة.",
+  "Discover exclusive offers and book appointments effortlessly to keep you looking your best.": "اكتشف العروض الحصرية واحجز المواعيد بسهولة لتحافظ على أفضل مظهر لك.",
+  "Have questions or feedback? Fill out the form below and we'll get back to you soon.": "هل لديك أسئلة أو ملاحظات؟ املأ النموذج أدناه وسنرد عليك قريبًا."
 }

--- a/WebsiteUser/src/locales/en/translation.json
+++ b/WebsiteUser/src/locales/en/translation.json
@@ -211,5 +211,8 @@
   "Comment": "Comment",
   "Enter your comment": "Enter your comment",
   "Submit": "Submit",
-  "Message sent successfully!": "Message sent successfully!"
+  "Message sent successfully!": "Message sent successfully!",
+  "MySalon connects you with trusted salons and stylists for quality beauty and grooming services.": "MySalon connects you with trusted salons and stylists for quality beauty and grooming services.",
+  "Discover exclusive offers and book appointments effortlessly to keep you looking your best.": "Discover exclusive offers and book appointments effortlessly to keep you looking your best.",
+  "Have questions or feedback? Fill out the form below and we'll get back to you soon.": "Have questions or feedback? Fill out the form below and we'll get back to you soon."
 }


### PR DESCRIPTION
## Summary
- add translation keys for About page paragraphs
- add description key for Contact page

## Testing
- `npm run lint` *(fails: 'motion' unused variable in other files)*

------
https://chatgpt.com/codex/tasks/task_e_687ba6e659ec832789d2aff9151e3495