### PR TITLE
Restrict CORS origins using env var

### DIFF
--- a/ExpressBackend/.env
+++ b/ExpressBackend/.env
@@ -5,3 +5,4 @@ SALT=10
 AZURE_STORAGE_CONNECTION_STRING=DefaultEndpointsProtocol=https;AccountName=mysalon;AccountKey=w6a461aYKQNwVhhLJA+iLgnfMomVSW6LTVWwf/aD3AX+4LxWn217pNKTms8ZnB6e3SXOXpMFS9DA+AStyXKzLw==;EndpointSuffix=core.windows.net
 AZURE_CONTAINER_NAME=mysalon
 AZURE_STORAGE_ACCOUNT_KEY=w6a461aYKQNwVhhLJA+iLgnfMomVSW6LTVWwf/aD3AX+4LxWn217pNKTms8ZnB6e3SXOXpMFS9DA+AStyXKzLw==
+ALLOWED_ORIGINS=http://localhost:3000,http://localhost:3001

--- a/ExpressBackend/server.js
+++ b/ExpressBackend/server.js
@@ -4,7 +4,21 @@ const cors = require('cors')
 const bodyParser = require('body-parser')
 require('dotenv').config()
 const app = express()
-app.use(cors())
+const allowedOrigins = (process.env.ALLOWED_ORIGINS || '')
+  .split(',')
+  .map((o) => o.trim())
+  .filter((o) => o)
+
+const corsOptions = {
+  origin: (origin, callback) => {
+    if (!origin || allowedOrigins.includes(origin)) {
+      callback(null, true)
+    } else {
+      callback(new Error('Not allowed by CORS'))
+    }
+  },
+}
+app.use(cors(corsOptions))
 app.use(bodyParser.json())
 app.use(express.json())
 


### PR DESCRIPTION
## Summary
- limit allowed origins to the list specified in `ALLOWED_ORIGINS`
- document allowed origins in `.env`

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ba6e8a6b88327a46cf015faf23cce