### PR TITLE
Add error boundary to React apps

### DIFF
--- a/WebsiteAdmin/src/ErrorBoundary.jsx
+++ b/WebsiteAdmin/src/ErrorBoundary.jsx
@@ -1,0 +1,30 @@
+import React, { Component } from 'react'
+
+class ErrorBoundary extends Component {
+  constructor(props) {
+    super(props)
+    this.state = { hasError: false }
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true }
+  }
+
+  componentDidCatch(error, errorInfo) {
+    console.error('ErrorBoundary caught an error', error, errorInfo)
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div style={{ padding: '2rem', textAlign: 'center' }}>
+          <h1>Something went wrong.</h1>
+        </div>
+      )
+    }
+
+    return this.props.children
+  }
+}
+
+export default ErrorBoundary

--- a/WebsiteAdmin/src/main.jsx
+++ b/WebsiteAdmin/src/main.jsx
@@ -3,5 +3,10 @@ import 'bootstrap/dist/css/bootstrap.min.css'
 import 'bootstrap/dist/js/bootstrap.bundle.min'
 
 import App from './App.jsx'
+import ErrorBoundary from './ErrorBoundary.jsx'
 
-createRoot(document.getElementById('root')).render(<App />)
+createRoot(document.getElementById('root')).render(
+  <ErrorBoundary>
+    <App />
+  </ErrorBoundary>
+)

--- a/WebsiteSalon/src/ErrorBoundary.jsx
+++ b/WebsiteSalon/src/ErrorBoundary.jsx
@@ -1,0 +1,30 @@
+import React, { Component } from 'react'
+
+class ErrorBoundary extends Component {
+  constructor(props) {
+    super(props)
+    this.state = { hasError: false }
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true }
+  }
+
+  componentDidCatch(error, errorInfo) {
+    console.error('ErrorBoundary caught an error', error, errorInfo)
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div style={{ padding: '2rem', textAlign: 'center' }}>
+          <h1>Something went wrong.</h1>
+        </div>
+      )
+    }
+
+    return this.props.children
+  }
+}
+
+export default ErrorBoundary

--- a/WebsiteSalon/src/main.jsx
+++ b/WebsiteSalon/src/main.jsx
@@ -4,11 +4,14 @@ import ReactDOM from 'react-dom/client'
 import { BrowserRouter } from 'react-router-dom'
 import App from './App'
 import { AuthProvider } from './context/AuthContext'
+import ErrorBoundary from './ErrorBoundary.jsx'
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <BrowserRouter>
-    <AuthProvider>
-      <App />
-    </AuthProvider>
+    <ErrorBoundary>
+      <AuthProvider>
+        <App />
+      </AuthProvider>
+    </ErrorBoundary>
   </BrowserRouter>
 )

--- a/WebsiteUser/src/ErrorBoundary.jsx
+++ b/WebsiteUser/src/ErrorBoundary.jsx
@@ -1,0 +1,30 @@
+import React, { Component } from 'react'
+
+class ErrorBoundary extends Component {
+  constructor(props) {
+    super(props)
+    this.state = { hasError: false }
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true }
+  }
+
+  componentDidCatch(error, errorInfo) {
+    console.error('ErrorBoundary caught an error', error, errorInfo)
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div style={{ padding: '2rem', textAlign: 'center' }}>
+          <h1>Something went wrong.</h1>
+        </div>
+      )
+    }
+
+    return this.props.children
+  }
+}
+
+export default ErrorBoundary

--- a/WebsiteUser/src/main.jsx
+++ b/WebsiteUser/src/main.jsx
@@ -1,11 +1,14 @@
 // main.jsx or index.jsx
 import { createRoot } from 'react-dom/client'
 import App from './App.jsx'
+import ErrorBoundary from './ErrorBoundary.jsx'
 import { BrowserRouter } from 'react-router-dom'
 import './i18n'
 
 createRoot(document.getElementById('root')).render(
   <BrowserRouter>
-    <App />
+    <ErrorBoundary>
+      <App />
+    </ErrorBoundary>
   </BrowserRouter>
 )


### PR DESCRIPTION
## Summary
- add `ErrorBoundary.jsx` to each React app
- wrap top-level routes in `ErrorBoundary` for admin, user, and salon apps

## Testing
- `npm ci` && `npm run lint` in `WebsiteAdmin`
- `npm ci` && `npm run lint` *(fails: Cannot find package '@eslint/js')* in `WebsiteUser`
- `npm ci` && `npm run lint` in `WebsiteSalon`


------
https://chatgpt.com/codex/tasks/task_e_687ba6e8c7188327986a6ed342e7bf7e