### PR TITLE
Add context provider for auth & cart

### DIFF
--- a/WebsiteUser/src/App.jsx
+++ b/WebsiteUser/src/App.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState, useContext } from 'react'
 import { Routes, Route, useLocation } from 'react-router-dom'
 // Layout
 import Navbar from './components/layout/Navbar'
@@ -37,32 +37,17 @@ import NotFound from './components/NotFound'
 
 // Misc
 import backgroundImage from './assets/Background.png'
+import { AppContext } from './context/AppContext'
 
 const App = () => {
   const location = useLocation()
   const [userType, setUserType] = useState('Women')
-  const [user, setUser] = useState(null)
-  const [isUserLoaded, setIsUserLoaded] = useState(false)
+  const { user, authLoaded } = useContext(AppContext)
 
   const showNavbar = !['/signin', '/signup'].includes(location.pathname)
 
-  useEffect(() => {
-    const storedUser = localStorage.getItem('user')
-    if (storedUser && storedUser !== 'undefined') {
-      try {
-        const parsedUser = JSON.parse(storedUser)
-        setUser(parsedUser)
-      } catch {
-        setUser(null)
-      }
-    } else {
-      setUser(null)
-    }
-    setIsUserLoaded(true)
-  }, [location])
-
   const userId = user?.id
-  if (!isUserLoaded) return null
+  if (!authLoaded) return null
 
   return (
     <div
@@ -76,12 +61,7 @@ const App = () => {
       }}
     >
       {showNavbar && (
-        <Navbar
-          user={user}
-          setUser={setUser}
-          userType={userType}
-          setUserType={setUserType}
-        />
+        <Navbar user={user} userType={userType} setUserType={setUserType} />
       )}
 
       <div
@@ -116,7 +96,7 @@ const App = () => {
           <Route path="/contact" element={<ContactUs />} />
           <Route path="/account" element={<Account user={user} />} />
 
-          <Route path="/signin" element={<SignIn setUser={setUser} />} />
+          <Route path="/signin" element={<SignIn />} />
           <Route path="/signup" element={<SignUp />} />
           <Route
             path="/edit-profile"

--- a/WebsiteUser/src/components/auth/Signin.jsx
+++ b/WebsiteUser/src/components/auth/Signin.jsx
@@ -81,7 +81,11 @@ const SignUpLink = styled.a`
     text-decoration: underline;
   }
 `
-const SignIn = ({ setUser }) => {
+import { useContext } from 'react'
+import { AppContext } from '../../context/AppContext'
+
+const SignIn = () => {
+  const { setUser } = useContext(AppContext)
   const {
     t,
     username,
@@ -90,7 +94,7 @@ const SignIn = ({ setUser }) => {
     setPassword,
     error,
     handleSignIn
-  } = useSignIn({ setUser })
+  } = useSignIn()
 
   const onSubmit = (e) => {
     e.preventDefault()

--- a/WebsiteUser/src/components/layout/Navbar.jsx
+++ b/WebsiteUser/src/components/layout/Navbar.jsx
@@ -1,7 +1,7 @@
 import Dropdown from 'react-bootstrap/Dropdown'
 import { Link } from 'react-router-dom'
 import useNavbar from '../../functionality/layout/UseNavbar'
-const Navbar = ({ setUserType, userType, user, setUser }) => {
+const Navbar = ({ setUserType, userType, user }) => {
   const {
     t,
     i18n,
@@ -12,7 +12,7 @@ const Navbar = ({ setUserType, userType, user, setUser }) => {
     handleLogout,
     navLinks,
     location
-  } = useNavbar({ userType, setUserType, setUser })
+  } = useNavbar({ userType, setUserType })
 
   return (
     <>

--- a/WebsiteUser/src/context/AppContext.jsx
+++ b/WebsiteUser/src/context/AppContext.jsx
@@ -1,0 +1,47 @@
+import { createContext, useEffect, useState } from 'react'
+
+export const AppContext = createContext(null)
+
+export const AppProvider = ({ children }) => {
+  const [user, setUser] = useState(null)
+  const [cart, setCartState] = useState([])
+  const [authLoaded, setAuthLoaded] = useState(false)
+  const [cartLoaded, setCartLoaded] = useState(false)
+
+  useEffect(() => {
+    const storedUser = localStorage.getItem('user')
+    if (storedUser && storedUser !== 'undefined') {
+      try {
+        setUser(JSON.parse(storedUser))
+      } catch {
+        setUser(null)
+      }
+    } else {
+      setUser(null)
+    }
+    setAuthLoaded(true)
+  }, [])
+
+  useEffect(() => {
+    const stored = localStorage.getItem('cart')
+    if (stored) {
+      try {
+        setCartState(JSON.parse(stored))
+      } catch {
+        setCartState([])
+      }
+    }
+    setCartLoaded(true)
+  }, [])
+
+  const setCart = (updated) => {
+    setCartState(updated)
+    localStorage.setItem('cart', JSON.stringify(updated))
+  }
+
+  return (
+    <AppContext.Provider value={{ user, setUser, cart, setCart, authLoaded, cartLoaded }}>
+      {children}
+    </AppContext.Provider>
+  )
+}

--- a/WebsiteUser/src/functionality/auth/UseSignIn.jsx
+++ b/WebsiteUser/src/functionality/auth/UseSignIn.jsx
@@ -1,8 +1,10 @@
-import { useState } from 'react'
+import { useState, useContext } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
+import { AppContext } from '../../context/AppContext'
 
-const useSignIn = ({ setUser }) => {
+const useSignIn = () => {
+  const { setUser } = useContext(AppContext)
   const navigate = useNavigate()
   const { t } = useTranslation()
 

--- a/WebsiteUser/src/functionality/cart/UseCart.jsx
+++ b/WebsiteUser/src/functionality/cart/UseCart.jsx
@@ -1,28 +1,17 @@
-import { useState, useEffect } from 'react'
+import { useContext } from 'react'
 import { useNavigate } from 'react-router-dom'
 import axios from 'axios'
 import { useTranslation } from 'react-i18next'
 import { API_URL } from '../../config'
+import { AppContext } from '../../context/AppContext'
 
 const useCart = () => {
   const { t } = useTranslation()
   const navigate = useNavigate()
-  const [cart, setCart] = useState([])
-
-  useEffect(() => {
-    const stored = localStorage.getItem('cart')
-    if (stored) {
-      try {
-        setCart(JSON.parse(stored))
-      } catch (error) {
-        console.error('Error parsing cart:', error)
-      }
-    }
-  }, [])
+  const { cart, setCart } = useContext(AppContext)
 
   const updateCartStorage = (updated) => {
     setCart(updated)
-    localStorage.setItem('cart', JSON.stringify(updated))
   }
 
   const increaseQuantity = (item) => {

--- a/WebsiteUser/src/functionality/layout/UseNavbar.jsx
+++ b/WebsiteUser/src/functionality/layout/UseNavbar.jsx
@@ -1,12 +1,14 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useContext } from 'react'
 import { useNavigate, useLocation } from 'react-router-dom'
 import axios from 'axios'
 import { useTranslation } from 'react-i18next'
 import { API_URL } from '../../config'
+import { AppContext } from '../../context/AppContext'
 
 console.log('✅ API_URL:', API_URL)
 
-const useNavbar = ({ userType, setUser }) => {
+const useNavbar = ({ userType }) => {
+  const { setUser } = useContext(AppContext)
   const { t, i18n } = useTranslation()
   const [types, setTypes] = useState([])
   const [currentIcon, setCurrentIcon] = useState(null)

--- a/WebsiteUser/src/main.jsx
+++ b/WebsiteUser/src/main.jsx
@@ -2,10 +2,13 @@
 import { createRoot } from 'react-dom/client'
 import App from './App.jsx'
 import { BrowserRouter } from 'react-router-dom'
+import { AppProvider } from './context/AppContext'
 import './i18n'
 
 createRoot(document.getElementById('root')).render(
   <BrowserRouter>
-    <App />
+    <AppProvider>
+      <App />
+    </AppProvider>
   </BrowserRouter>
 )


### PR DESCRIPTION
## Summary
- create `AppContext` to store user and cart
- wrap main app in `AppProvider`
- refactor auth and cart logic to use context

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_687ba6eb2430832799fed145261f23e7