### PR TITLE
Add reusable ServerError component

### DIFF
--- a/WebsiteUser/src/components/ServerError.jsx
+++ b/WebsiteUser/src/components/ServerError.jsx
@@ -1,0 +1,15 @@
+import React from 'react'
+
+const ServerError = ({ onRetry }) => (
+  <div className="d-flex flex-column align-items-center justify-content-center text-center py-5">
+    <h2 className="mb-3">Server Error</h2>
+    <p className="mb-4">Something went wrong on our end. Please try again.</p>
+    {onRetry && (
+      <button className="btn btn-primary" onClick={onRetry}>
+        Retry
+      </button>
+    )}
+  </div>
+)
+
+export default ServerError

--- a/WebsiteUser/src/components/orders/BookingDetailsPage.jsx
+++ b/WebsiteUser/src/components/orders/BookingDetailsPage.jsx
@@ -3,6 +3,7 @@ import { Helmet } from 'react-helmet'
 import styled from 'styled-components'
 import { useTranslation } from 'react-i18next'
 import useBookingDetails from '../../functionality/orders/UseBookingDetails'
+import ServerError from '../ServerError'
 
 const Container = styled.div`
   max-width: 800px;
@@ -88,6 +89,7 @@ const BookingDetailsPage = () => {
     booking,
     loading,
     error,
+    retry,
     cancelError,
     handleCancelBooking,
     formatDate
@@ -102,6 +104,9 @@ const BookingDetailsPage = () => {
   }
 
   if (error) {
+    if (error.response?.status === 500) {
+      return <ServerError onRetry={retry} />
+    }
     return (
       <LoadingContainer>
         <ErrorText>{t('Failed to load booking details.')}</ErrorText>

--- a/WebsiteUser/src/components/orders/MyBookings.jsx
+++ b/WebsiteUser/src/components/orders/MyBookings.jsx
@@ -4,6 +4,7 @@ import { Helmet } from 'react-helmet'
 import { useNavigate } from 'react-router-dom'
 import styled from 'styled-components'
 import useMyBookings from '../../functionality/orders/UseMyBookings'
+import ServerError from '../ServerError'
 
 const Container = styled.div`
   color: #ddd;
@@ -79,7 +80,9 @@ const MyBookings = () => {
     formatTime,
     groupOrderItems,
     handleRequestCancel,
-    handleRequestCancelOrder
+    handleRequestCancelOrder,
+    bookingsRetry,
+    ordersRetry
   } = useMyBookings(t, user)
 
   const typeFilters = ['All', 'Bookings', 'Orders']
@@ -121,6 +124,9 @@ const MyBookings = () => {
   }
 
   if (bookingsError || ordersError) {
+    if (bookingsError?.response?.status === 500 || ordersError?.response?.status === 500) {
+      return <ServerError onRetry={bookingsError ? bookingsRetry : ordersRetry} />
+    }
     return (
       <p className="text-center text-danger mt-5">
         {t('Failed to load bookings or orders.')}

--- a/WebsiteUser/src/components/orders/OrderDetailsPage.jsx
+++ b/WebsiteUser/src/components/orders/OrderDetailsPage.jsx
@@ -5,6 +5,7 @@ import styled from 'styled-components'
 import { useTranslation } from 'react-i18next'
 import { API_URL } from '../../config'
 import useFetch from '../../hooks/useFetch'
+import ServerError from '../ServerError'
 
 const Container = styled.div`
   max-width: 800px;
@@ -101,7 +102,8 @@ const OrderDetailsPage = () => {
   const {
     data: orderData,
     loading,
-    error
+    error,
+    retry
   } = useFetch(
     state?.order
       ? null
@@ -156,6 +158,9 @@ const OrderDetailsPage = () => {
   }
 
   if (error) {
+    if (error.response?.status === 500) {
+      return <ServerError onRetry={retry} />
+    }
     return (
       <Container>
         <Text style={{ color: '#f44336' }}>

--- a/WebsiteUser/src/components/products/Favorites.jsx
+++ b/WebsiteUser/src/components/products/Favorites.jsx
@@ -3,10 +3,11 @@ import { Spinner } from 'react-bootstrap'
 import { useTranslation } from 'react-i18next'
 import { Helmet } from 'react-helmet'
 import { useNavigate } from 'react-router-dom'
-import { motion } from 'framer-motion'
+import { motion as Motion } from 'framer-motion'
 import styled from 'styled-components'
 import 'bootstrap/dist/css/bootstrap.min.css'
 import useFavorites from '../../functionality/products/UseFavorites'
+import ServerError from '../ServerError'
 
 const Container = styled.div`
   color: #ddd;
@@ -64,7 +65,7 @@ const Favorites = ({ userId, userType }) => {
   const [sortBy, setSortBy] = useState('distance')
   const [showFilters, setShowFilters] = useState(false)
 
-  const { favorites, loading, error, toggleFavorite } = useFavorites(
+  const { favorites, loading, error, toggleFavorite, retry } = useFavorites(
     userId,
     userType
   )
@@ -78,6 +79,9 @@ const Favorites = ({ userId, userType }) => {
   }
 
   if (error) {
+    if (error.response?.status === 500) {
+      return <ServerError onRetry={retry} />
+    }
     return (
       <div className="text-center mt-5 text-danger">
         {t('Failed to load favorites')}
@@ -190,7 +194,7 @@ const Favorites = ({ userId, userType }) => {
       ) : (
         <div className="row">
           {sortedFavorites.map((salon) => (
-            <motion.div
+            <Motion.div
               key={salon.id}
               className="col-md-4 mb-4"
               initial={{ opacity: 0, y: 50 }}
@@ -264,7 +268,7 @@ const Favorites = ({ userId, userType }) => {
                   </div>
                 </div>
               </CardStyled>
-            </motion.div>
+            </Motion.div>
           ))}
         </div>
       )}

--- a/WebsiteUser/src/components/products/Packages.jsx
+++ b/WebsiteUser/src/components/products/Packages.jsx
@@ -3,6 +3,7 @@ import { Spinner } from 'react-bootstrap'
 import { Helmet } from 'react-helmet'
 import { useTranslation } from 'react-i18next'
 import usePackages from '../../functionality/products/UsePackages'
+import ServerError from '../ServerError'
 
 const Packages = () => {
   const { t } = useTranslation()
@@ -12,6 +13,7 @@ const Packages = () => {
     packages,
     loading,
     error,
+    retry,
     successMessage,
     sortOption,
     handleSort,
@@ -90,9 +92,13 @@ const Packages = () => {
           <Spinner animation="border" variant="light" />
         </div>
       ) : error ? (
-        <p className="text-center text-danger">
-          {t('Failed to load packages')}
-        </p>
+        error.response?.status === 500 ? (
+          <ServerError onRetry={retry} />
+        ) : (
+          <p className="text-center text-danger">
+            {t('Failed to load packages')}
+          </p>
+        )
       ) : packages.length === 0 ? (
         <p className="text-center text-muted fst-italic">
           {t('no_packages_found')}

--- a/WebsiteUser/src/components/products/Products.jsx
+++ b/WebsiteUser/src/components/products/Products.jsx
@@ -4,6 +4,7 @@ import { Helmet } from 'react-helmet'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 import useProducts from '../../functionality/products/UseProducts'
+import ServerError from '../ServerError'
 
 const Container = styled.div`
   color: #ddd;
@@ -75,6 +76,7 @@ const Products = () => {
     products,
     loading,
     error,
+    retry,
     sortOption,
     successMessage,
     handleSort,
@@ -92,6 +94,9 @@ const Products = () => {
   }
 
   if (error) {
+    if (error.response?.status === 500) {
+      return <ServerError onRetry={retry} />
+    }
     return (
       <div className="text-center mt-5 text-danger">
         {t('Failed to load products')}

--- a/WebsiteUser/src/components/salons/NearestSalon.jsx
+++ b/WebsiteUser/src/components/salons/NearestSalon.jsx
@@ -3,9 +3,10 @@ import { Spinner } from 'react-bootstrap'
 import { useTranslation } from 'react-i18next'
 import { Helmet } from 'react-helmet'
 import { useNavigate } from 'react-router-dom'
-import { motion } from 'framer-motion'
+import { motion as Motion } from 'framer-motion'
 import styled from 'styled-components'
 import useNearestSalons from '../../functionality/salons/useNearestSalons'
+import ServerError from '../ServerError'
 
 const Container = styled.div`
   color: #ddd;
@@ -71,7 +72,8 @@ const NearestSalon = ({ userType, userId }) => {
     setMaxDistance,
     sortBy,
     setSortBy,
-    toggleFavorite
+    toggleFavorite,
+    retry
   } = useNearestSalons(userType, userId)
 
   if (loading) {
@@ -83,6 +85,9 @@ const NearestSalon = ({ userType, userId }) => {
   }
 
   if (error) {
+    if (error.response?.status === 500) {
+      return <ServerError onRetry={retry} />
+    }
     return (
       <div className="text-center mt-5 text-danger">
         {t('Failed to load salons')}
@@ -199,7 +204,7 @@ const NearestSalon = ({ userType, userId }) => {
           {sortedSalons.map((salon) => {
             const isFavorited = favorites.has(salon.id)
             return (
-              <motion.div
+              <Motion.div
                 key={salon.id}
                 className="col-md-4 mb-4"
                 initial={{ opacity: 0, y: 50 }}
@@ -280,7 +285,7 @@ const NearestSalon = ({ userType, userId }) => {
                     </div>
                   </div>
                 </CardStyled>
-              </motion.div>
+              </Motion.div>
             )
           })}
         </div>

--- a/WebsiteUser/src/components/salons/SalonDetails.jsx
+++ b/WebsiteUser/src/components/salons/SalonDetails.jsx
@@ -8,6 +8,7 @@ import markerIcon2x from 'leaflet/dist/images/marker-icon-2x.png'
 import markerIcon from 'leaflet/dist/images/marker-icon.png'
 import markerShadow from 'leaflet/dist/images/marker-shadow.png'
 import useSalonDetails from '../../functionality/salons/UseSalonDetails'
+import ServerError from '../ServerError'
 // Fix Leaflet marker icon issue
 delete L.Icon.Default.prototype._getIconUrl
 L.Icon.Default.mergeOptions({
@@ -21,7 +22,7 @@ const SalonDetails = () => {
   const navigate = useNavigate()
   const { t } = useTranslation()
 
-  const { salon, loading, error, isMobile, latitude, longitude } =
+  const { salon, loading, error, retry, isMobile, latitude, longitude } =
     useSalonDetails(id)
 
   if (loading) {
@@ -32,7 +33,18 @@ const SalonDetails = () => {
     )
   }
 
-  if (error || !salon) {
+  if (error) {
+    if (error.response?.status === 500) {
+      return <ServerError onRetry={retry} />
+    }
+    return (
+      <p style={{ textAlign: 'center', color: '#bbb' }}>
+        {t('Salon not found')}
+      </p>
+    )
+  }
+
+  if (!salon) {
     return (
       <p style={{ textAlign: 'center', color: '#bbb' }}>
         {t('Salon not found')}

--- a/WebsiteUser/src/functionality/orders/UseBookingDetails.jsx
+++ b/WebsiteUser/src/functionality/orders/UseBookingDetails.jsx
@@ -8,7 +8,8 @@ const useBookingDetails = (id, t) => {
   const {
     data: bookingData,
     loading,
-    error
+    error,
+    retry
   } = useFetch(`${API_URL}/bookings/${id}`, [id])
 
   const [booking, setBooking] = useState(null)
@@ -58,6 +59,7 @@ const useBookingDetails = (id, t) => {
     booking,
     loading,
     error,
+    retry,
     cancelError,
     handleCancelBooking,
     formatDate

--- a/WebsiteUser/src/functionality/orders/UseMyBookings.jsx
+++ b/WebsiteUser/src/functionality/orders/UseMyBookings.jsx
@@ -11,13 +11,15 @@ const useMyBookings = (t, user) => {
   const {
     data: bookingsData = [],
     loading: bookingsLoading,
-    error: bookingsError
+    error: bookingsError,
+    retry: bookingsRetry
   } = useFetch(user?.id ? `${API_URL}/bookings` : null, [user?.id])
 
   const {
     data: ordersData = [],
     loading: ordersLoading,
-    error: ordersError
+    error: ordersError,
+    retry: ordersRetry
   } = useFetch(user?.id ? `${API_URL}/orders/${user.id}` : null, [
     user?.id
   ])
@@ -157,6 +159,8 @@ const useMyBookings = (t, user) => {
     ordersLoading,
     bookingsError,
     ordersError,
+    bookingsRetry,
+    ordersRetry,
     filteredData,
     formatDate,
     formatTime,

--- a/WebsiteUser/src/functionality/products/UseFavorites.jsx
+++ b/WebsiteUser/src/functionality/products/UseFavorites.jsx
@@ -21,36 +21,37 @@ export default function useFavorites(userId, userType) {
     }
   }, [])
 
-  useEffect(() => {
-    const fetchFavorites = async () => {
-      if (!userId || !userLocation) return
-      setLoading(true)
-      try {
-        const res = await fetch(
-          `${API_URL}/favorites/${userId}?type=${userType}`
-        )
-        const data = await res.json()
-        const array = Array.isArray(data) ? data : []
-        const enriched = array.map((salon) => ({
-          ...salon,
-          distance:
-            salon.latitude && salon.longitude
-              ? calculateDistance(
-                  userLocation.latitude,
-                  userLocation.longitude,
-                  salon.latitude,
-                  salon.longitude
-                )
-              : null
-        }))
-        setFavorites(enriched)
-      } catch (err) {
-        console.error('Fetch favorites error:', err)
-        setError(err.message || 'Failed to fetch')
-      } finally {
-        setLoading(false)
-      }
+  const fetchFavorites = async () => {
+    if (!userId || !userLocation) return
+    setLoading(true)
+    try {
+      const res = await fetch(
+        `${API_URL}/favorites/${userId}?type=${userType}`
+      )
+      const data = await res.json()
+      const array = Array.isArray(data) ? data : []
+      const enriched = array.map((salon) => ({
+        ...salon,
+        distance:
+          salon.latitude && salon.longitude
+            ? calculateDistance(
+                userLocation.latitude,
+                userLocation.longitude,
+                salon.latitude,
+                salon.longitude
+              )
+            : null
+      }))
+      setFavorites(enriched)
+    } catch (err) {
+      console.error('Fetch favorites error:', err)
+      setError(err)
+    } finally {
+      setLoading(false)
     }
+  }
+
+  useEffect(() => {
     fetchFavorites()
   }, [userId, userType, userLocation])
 
@@ -83,5 +84,5 @@ export default function useFavorites(userId, userType) {
     }
   }
 
-  return { favorites, loading, error, toggleFavorite, userLocation }
+  return { favorites, loading, error, toggleFavorite, userLocation, retry: fetchFavorites }
 }

--- a/WebsiteUser/src/functionality/products/UsePackages.jsx
+++ b/WebsiteUser/src/functionality/products/UsePackages.jsx
@@ -9,7 +9,8 @@ export default function usePackages(t) {
   const {
     data: fetchedPackages = [],
     loading,
-    error
+    error,
+    retry
   } = useFetch(`${API_URL}/package`, [])
 
   const [packages, setPackages] = useState([])
@@ -94,6 +95,7 @@ export default function usePackages(t) {
     packages,
     loading,
     error,
+    retry,
     successMessage,
     sortOption,
     handleSort,

--- a/WebsiteUser/src/functionality/products/UseProducts.jsx
+++ b/WebsiteUser/src/functionality/products/UseProducts.jsx
@@ -6,7 +6,8 @@ export default function useProducts(t) {
   const {
     data: fetchedProducts = [],
     loading,
-    error
+    error,
+    retry
   } = useFetch(`${API_URL}/product`, [])
 
   const [products, setProducts] = useState([])
@@ -93,6 +94,7 @@ export default function useProducts(t) {
     products,
     loading,
     error,
+    retry,
     sortOption,
     successMessage,
     handleSort,

--- a/WebsiteUser/src/functionality/salons/UseSalonDetails.jsx
+++ b/WebsiteUser/src/functionality/salons/UseSalonDetails.jsx
@@ -15,7 +15,8 @@ export default function useSalonDetails(id) {
   const {
     data: salon,
     loading,
-    error
+    error,
+    retry
   } = useFetch(id ? `${API_URL}/salons/${id}` : null, [id])
 
   const latitude =
@@ -27,6 +28,7 @@ export default function useSalonDetails(id) {
     salon,
     loading,
     error,
+    retry,
     isMobile,
     latitude,
     longitude

--- a/WebsiteUser/src/functionality/salons/useNearestSalons.jsx
+++ b/WebsiteUser/src/functionality/salons/useNearestSalons.jsx
@@ -124,6 +124,7 @@ export default function useNearestSalons(userType, userId) {
     setMaxDistance,
     sortBy,
     setSortBy,
-    toggleFavorite
+    toggleFavorite,
+    retry: refetch
   }
 }

--- a/WebsiteUser/src/hooks/useFetch.jsx
+++ b/WebsiteUser/src/hooks/useFetch.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useCallback } from 'react'
 import axios from 'axios'
 
 const useFetch = (url, deps = []) => {
@@ -6,39 +6,40 @@ const useFetch = (url, deps = []) => {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(null)
 
-  useEffect(() => {
+  const fetchData = useCallback(async () => {
     if (!url) {
       setData([])
       setLoading(false)
       return
     }
 
-    const fetchData = async () => {
-      setLoading(true)
-      setError(null)
+    setLoading(true)
+    setError(null)
 
-      try {
-        console.log('🌐 Fetching from:', url)
-        const response = await axios.get(url)
-        console.log('✅ Fetched data:', response.data)
-        setData(response.data || [])
-      } catch (err) {
-        if (axios.isAxiosError(err)) {
-          console.error('❌ Axios error:', err.response?.data || err.message)
-        } else {
-          console.error('❌ Unknown error:', err)
-        }
-        setError(err)
-        setData([])
-      } finally {
-        setLoading(false)
+    try {
+      console.log('🌐 Fetching from:', url)
+      const response = await axios.get(url)
+      console.log('✅ Fetched data:', response.data)
+      setData(response.data || [])
+    } catch (err) {
+      if (axios.isAxiosError(err)) {
+        console.error('❌ Axios error:', err.response?.data || err.message)
+      } else {
+        console.error('❌ Unknown error:', err)
       }
+      setError(err)
+      setData([])
+    } finally {
+      setLoading(false)
     }
+  }, [url])
 
+  useEffect(() => {
     fetchData()
-  }, deps)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [fetchData, ...deps])
 
-  return { data, loading, error }
+  return { data, loading, error, retry: fetchData, refetch: fetchData }
 }
 
 export default useFetch


### PR DESCRIPTION
## Summary
- add a `ServerError` component for displaying friendly server error messages
- extend `useFetch` with retry support and return it from hooks
- show `ServerError` when 500 errors occur across user pages and hooks

## Testing
- `npm run lint` in `WebsiteUser`
- `npm run lint` in `WebsiteAdmin`
- `npm run lint` in `WebsiteSalon`


------
https://chatgpt.com/codex/tasks/task_e_687ba6ed378883278ab9bb4b3f26782d