### PR TITLE
Add Poppins font globally

### DIFF
--- a/WebsiteAdmin/index.html
+++ b/WebsiteAdmin/index.html
@@ -13,6 +13,13 @@
     <!-- Bootstrap JS Bundle (with Popper) -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/js/bootstrap.bundle.min.js"></script>
 
+    <link href="https://fonts.googleapis.com/css2?family=Poppins&display=swap" rel="stylesheet" />
+    <style>
+      body {
+        font-family: 'Poppins', sans-serif;
+      }
+    </style>
+
     <title>Vite + React</title>
   </head>
   <body>

--- a/WebsiteSalon/index.html
+++ b/WebsiteSalon/index.html
@@ -13,6 +13,13 @@
       href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
     />
 
+    <link href="https://fonts.googleapis.com/css2?family=Poppins&display=swap" rel="stylesheet" />
+    <style>
+      body {
+        font-family: 'Poppins', sans-serif;
+      }
+    </style>
+
     <title>Vite + React</title>
   </head>
   <body>

--- a/WebsiteUser/index.html
+++ b/WebsiteUser/index.html
@@ -19,6 +19,12 @@
     <script src="https://hostedcheckout.mastercard.com/checkout/version/63/checkout.js"></script>
 
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link href="https://fonts.googleapis.com/css2?family=Poppins&display=swap" rel="stylesheet" />
+    <style>
+      body {
+        font-family: 'Poppins', sans-serif;
+      }
+    </style>
     <title>Vite + React</title>
   </head>
   <body>


### PR DESCRIPTION
## Summary
- include Google Fonts link for Poppins in each website's `index.html`
- set a global `body { font-family: 'Poppins', sans-serif; }` rule

## Testing
- `npm test` *(fails: Invalid package.json)*
- `npm run cy:run` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687e88f5e4148327bd558ec51cd4619a