### PR TITLE
Add LoadingSpinner component to user site

### DIFF
--- a/WebsiteUser/package.json
+++ b/WebsiteUser/package.json
@@ -8,7 +8,7 @@
     "build": "vite build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "test": "vitest"
+    "test": "vitest",
     "format": "prettier --write ."
   },
   "dependencies": {

--- a/WebsiteUser/src/components/LoadingSpinner.jsx
+++ b/WebsiteUser/src/components/LoadingSpinner.jsx
@@ -1,0 +1,18 @@
+import React from 'react'
+import { Spinner } from 'react-bootstrap'
+
+/**
+ * Simple centered loading spinner used across the website.
+ * Additional className or style can be passed through props.
+ */
+const LoadingSpinner = ({ className = '', style, ...props }) => (
+  <div
+    className={`d-flex justify-content-center align-items-center ${className}`}
+    style={style}
+    {...props}
+  >
+    <Spinner animation="border" variant="light" />
+  </div>
+)
+
+export default LoadingSpinner

--- a/WebsiteUser/src/components/orders/SalonBooking.jsx
+++ b/WebsiteUser/src/components/orders/SalonBooking.jsx
@@ -1,5 +1,6 @@
 import { useParams, useNavigate } from 'react-router-dom'
-import { Spinner, Button, Alert, Row, Col, Card } from 'react-bootstrap'
+import { Button, Alert, Row, Col, Card } from 'react-bootstrap'
+import LoadingSpinner from '../LoadingSpinner'
 import { useTranslation } from 'react-i18next'
 import moment from 'moment'
 import PropTypes from 'prop-types'
@@ -30,11 +31,7 @@ const SalonBooking = ({ userId }) => {
   } = useSalonBooking({ salonId: id, userId, t, navigate })
 
   if (loading) {
-    return (
-      <div className="d-flex justify-content-center align-items-center mt-5">
-        <Spinner animation="border" variant="light" />
-      </div>
-    )
+    return <LoadingSpinner className="mt-5" />
   }
 
   if (!salon) {

--- a/WebsiteUser/src/components/products/Favorites.jsx
+++ b/WebsiteUser/src/components/products/Favorites.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { Spinner } from 'react-bootstrap'
+import LoadingSpinner from '../LoadingSpinner'
 import { useTranslation } from 'react-i18next'
 import { Helmet } from 'react-helmet'
 import { useNavigate } from 'react-router-dom'
@@ -71,11 +71,7 @@ const Favorites = ({ userId, userType }) => {
   )
 
   if (loading) {
-    return (
-      <div className="d-flex justify-content-center py-4">
-        <Spinner animation="border" variant="light" />
-      </div>
-    )
+    return <LoadingSpinner className="py-4" />
   }
 
   if (error) {

--- a/WebsiteUser/src/components/products/Packages.jsx
+++ b/WebsiteUser/src/components/products/Packages.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { Spinner } from 'react-bootstrap'
+import LoadingSpinner from '../LoadingSpinner'
 import { Helmet } from 'react-helmet'
 import { useTranslation } from 'react-i18next'
 import usePackages from '../../functionality/products/UsePackages'
@@ -88,9 +88,7 @@ const Packages = () => {
       </div>
 
       {loading ? (
-        <div className="d-flex justify-content-center my-5">
-          <Spinner animation="border" variant="light" />
-        </div>
+        <LoadingSpinner className="my-5" />
       ) : error ? (
         error.response?.status === 500 ? (
           <ServerError onRetry={retry} />

--- a/WebsiteUser/src/components/products/Products.jsx
+++ b/WebsiteUser/src/components/products/Products.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { Spinner } from 'react-bootstrap'
+import LoadingSpinner from '../LoadingSpinner'
 import { Helmet } from 'react-helmet'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
@@ -86,11 +86,7 @@ const Products = () => {
   } = useProducts(t)
 
   if (loading) {
-    return (
-      <div className="d-flex justify-content-center my-5">
-        <Spinner animation="border" variant="light" />
-      </div>
-    )
+    return <LoadingSpinner className="my-5" />
   }
 
   if (error) {

--- a/WebsiteUser/src/components/salons/NearestSalon.jsx
+++ b/WebsiteUser/src/components/salons/NearestSalon.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { Spinner } from 'react-bootstrap'
+import LoadingSpinner from '../LoadingSpinner'
 import { useTranslation } from 'react-i18next'
 import { Helmet } from 'react-helmet'
 import { useNavigate } from 'react-router-dom'
@@ -78,11 +78,7 @@ const NearestSalon = ({ userType, userId }) => {
   } = useNearestSalons(userType, userId)
 
   if (loading) {
-    return (
-      <div className="d-flex justify-content-center py-4">
-        <Spinner animation="border" variant="light" />
-      </div>
-    )
+    return <LoadingSpinner className="py-4" />
   }
 
   if (error) {

--- a/WebsiteUser/src/components/salons/SalonDetails.jsx
+++ b/WebsiteUser/src/components/salons/SalonDetails.jsx
@@ -1,5 +1,6 @@
 import { useParams, useNavigate } from 'react-router-dom'
-import { Spinner, Button } from 'react-bootstrap'
+import { Button } from 'react-bootstrap'
+import LoadingSpinner from '../LoadingSpinner'
 import { useTranslation } from 'react-i18next'
 import { MapContainer, TileLayer, Marker } from 'react-leaflet'
 import 'leaflet/dist/leaflet.css'
@@ -26,11 +27,7 @@ const SalonDetails = () => {
     useSalonDetails(id)
 
   if (loading) {
-    return (
-      <div style={styles.centered}>
-        <Spinner animation="border" variant="info" />
-      </div>
-    )
+    return <LoadingSpinner style={styles.centered} />
   }
 
   if (error) {

--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "main": "index.js",
   "scripts": {
     "cy:open": "cypress open",
-    "cy:run": "cypress run"
+    "cy:run": "cypress run",
     "test": "echo \"Error: no test specified\" && exit 1",
-    "dev": "concurrently \"npm run nodemon --prefix ExpressBackend\" \"npm run dev --prefix WebsiteUser\""
+    "dev": "concurrently \"npm run nodemon --prefix ExpressBackend\" \"npm run dev --prefix WebsiteUser\"",
     "prepare": "husky install"
   },
   "keywords": [],
@@ -15,8 +15,8 @@
   "license": "ISC",
   "type": "commonjs",
   "devDependencies": {
-    "cypress": "^14.5.2"
-    "concurrently": "^9.2.0"
+    "cypress": "^14.5.2",
+    "concurrently": "^9.2.0",
     "husky": "^9.1.7"
   }
 }


### PR DESCRIPTION
## Summary
- add reusable `LoadingSpinner` component
- use the spinner on pages that previously had custom loading markup
- fix commas in package.json files to run tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687e890211348327a13d1b2ae8dc086b