### PR TITLE
Add scroll to top button

### DIFF
--- a/WebsiteUser/src/App.jsx
+++ b/WebsiteUser/src/App.jsx
@@ -38,6 +38,7 @@ import NotFound from './components/NotFound'
 // Misc
 import backgroundImage from './assets/Background.png'
 import { AppContext } from './context/AppContext'
+import ScrollToTop from './components/ScrollToTop'
 
 const App = () => {
   const location = useLocation()
@@ -113,6 +114,7 @@ const App = () => {
           <Route path="*" element={<NotFound />} />
         </Routes>
       </div>
+      <ScrollToTop />
     </div>
   )
 }

--- a/WebsiteUser/src/components/ScrollToTop.jsx
+++ b/WebsiteUser/src/components/ScrollToTop.jsx
@@ -1,0 +1,50 @@
+import React, { useState, useEffect } from 'react'
+import styled from 'styled-components'
+
+const Button = styled.button`
+  position: fixed;
+  bottom: 90px;
+  right: 20px;
+  width: 45px;
+  height: 45px;
+  border-radius: 50%;
+  border: none;
+  background-color: #4f8ef7;
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
+  opacity: ${(props) => (props.$visible ? 1 : 0)};
+  pointer-events: ${(props) => (props.$visible ? 'auto' : 'none')};
+  transition: opacity 0.3s ease;
+  z-index: 1000;
+`
+
+const ScrollToTop = () => {
+  const [visible, setVisible] = useState(false)
+
+  const handleScroll = () => {
+    const scrollTop = window.pageYOffset || document.documentElement.scrollTop
+    setVisible(scrollTop > 300)
+  }
+
+  useEffect(() => {
+    window.addEventListener('scroll', handleScroll)
+    return () => {
+      window.removeEventListener('scroll', handleScroll)
+    }
+  }, [])
+
+  const scrollToTop = () => {
+    window.scrollTo({ top: 0, behavior: 'smooth' })
+  }
+
+  return (
+    <Button onClick={scrollToTop} aria-label="Scroll to top" $visible={visible}>
+      <i className="bi bi-chevron-up"></i>
+    </Button>
+  )
+}
+
+export default ScrollToTop


### PR DESCRIPTION
## Summary
- add `ScrollToTop` component which appears after scrolling and smoothly returns to top
- integrate `ScrollToTop` in the user website near the footer area

## Testing
- `npx --yes --prefix WebsiteUser vitest run --silent` *(fails: cannot find module 'supertest')*

------
https://chatgpt.com/codex/tasks/task_e_687e8903e96483278d784a378e09d618