### PR TITLE
Add fade transition for user app routes

### DIFF
--- a/WebsiteUser/src/App.jsx
+++ b/WebsiteUser/src/App.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useContext } from 'react'
 import { Routes, Route, useLocation } from 'react-router-dom'
+import { AnimatePresence, motion } from 'framer-motion'
 // Layout
 import Navbar from './components/layout/Navbar'
 
@@ -71,7 +72,14 @@ const App = () => {
           maxWidth: '100%'
         }}
       >
-        <Routes>
+        <AnimatePresence mode="wait">
+          <motion.div
+            key={location.pathname}
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+          >
+            <Routes location={location}>
           <Route
             path="/"
             element={<NearestSalon userType={userType} userId={userId} />}
@@ -112,6 +120,8 @@ const App = () => {
           <Route path="/payment-success" element={<PaymentSuccess />} />
           <Route path="*" element={<NotFound />} />
         </Routes>
+          </motion.div>
+        </AnimatePresence>
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
- animate page transitions by wrapping `Routes` in `WebsiteUser/src/App.jsx`
  with `AnimatePresence` and `motion.div`

## Testing
- `npm test` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687e8907fef08327b9ae0b8caf11cd82