### PR TITLE
Add salon search filter

### DIFF
--- a/WebsiteUser/src/components/salons/NearestSalon.jsx
+++ b/WebsiteUser/src/components/salons/NearestSalon.jsx
@@ -61,6 +61,7 @@ const NearestSalon = ({ userType, userId }) => {
   const { t } = useTranslation()
   const navigate = useNavigate()
   const [showFilters, setShowFilters] = useState(false)
+  const [searchQuery, setSearchQuery] = useState('')
 
   const {
     loading,
@@ -101,7 +102,10 @@ const NearestSalon = ({ userType, userId }) => {
     const meetsRating = salon.rating >= minRating
     const meetsDistance =
       salon.distance !== null ? salon.distance <= maxDistance : false
-    return meetsRating && meetsDistance
+    const nameMatches = salon.name
+      .toLowerCase()
+      .includes(searchQuery.toLowerCase())
+    return meetsRating && meetsDistance && nameMatches
   })
 
   const sortedSalons = [...filteredSalons].sort((a, b) => {
@@ -194,6 +198,14 @@ const NearestSalon = ({ userType, userId }) => {
           </div>
         </FilterContainer>
       )}
+
+      <input
+        type="text"
+        className="form-control mb-3"
+        placeholder={t('Search salons')}
+        value={searchQuery}
+        onChange={(e) => setSearchQuery(e.target.value)}
+      />
 
       {/* Salon Cards */}
       {sortedSalons.length === 0 ? (

--- a/WebsiteUser/src/locales/ar/translation.json
+++ b/WebsiteUser/src/locales/ar/translation.json
@@ -20,6 +20,7 @@
   "Select Type": "اختر النوع",
   "Edit Account": "تعديل الحساب",
   "Filters": "الفلاتر",
+  "Search salons": "ابحث عن صالونات",
   "Subscribe": "اشترك",
   "Cancel": "إلغاء",
   "Add": "اضافة",

--- a/WebsiteUser/src/locales/en/translation.json
+++ b/WebsiteUser/src/locales/en/translation.json
@@ -20,6 +20,7 @@
   "Select Type": "Select Type",
   "Edit Account": "Edit Account",
   "Filters": "Filters",
+  "Search salons": "Search salons",
   "Subscribe": "Subscribe",
   "Cancel": "Cancel",
   "Add": "Add",


### PR DESCRIPTION
## Summary
- add local search state in NearestSalon
- filter salons by name using search input
- update translations with 'Search salons'

## Testing
- `npx vitest run --dir WebsiteUser` *(fails: cannot find @testing-library/react)*

------
https://chatgpt.com/codex/tasks/task_e_687e890e7454832796fbfc054d7f296d