### PR TITLE
Update training page with card grid

### DIFF
--- a/WebsiteUser/src/components/products/Training.jsx
+++ b/WebsiteUser/src/components/products/Training.jsx
@@ -37,9 +37,65 @@ const FilterButton = styled.button`
   }
 `
 
+const Grid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+  gap: 1rem;
+`
+
+const Card = styled.div`
+  background-color: #242424;
+  color: #f0f8ff;
+  border: 1px solid #444;
+  border-radius: 12px;
+  overflow: hidden;
+`
+
+const CardImage = styled.img`
+  height: 180px;
+  object-fit: cover;
+  width: 100%;
+  border-bottom: 1px solid #444;
+`
+
+const Placeholder = styled.div`
+  height: 180px;
+  font-size: 64px;
+  color: #ddd;
+  border-bottom: 1px solid #444;
+`
+
+const CardTitle = styled.h5`
+  color: #a3c1f7;
+  font-weight: 600;
+`
+
+const CardDescription = styled.p`
+  color: #bbb;
+  font-size: 0.9rem;
+`
+
 const Training = () => {
   const [showFilters, setShowFilters] = useState(false)
   const { t } = useTranslation()
+
+  const trainingPrograms = [
+    {
+      id: 1,
+      title: 'Hair Styling Basics',
+      description: 'Learn fundamental hair styling techniques.'
+    },
+    {
+      id: 2,
+      title: 'Advanced Makeup',
+      description: 'Master advanced makeup application skills.'
+    },
+    {
+      id: 3,
+      title: 'Nail Art Workshop',
+      description: 'Create stunning nail art designs.'
+    }
+  ]
 
   return (
     <Container>
@@ -60,6 +116,26 @@ const Training = () => {
           <p>Filters go here</p>
         </div>
       )}
+
+      <Grid>
+        {trainingPrograms.map((program) => (
+          <Card key={program.id}>
+            {program.image ? (
+              <CardImage src={program.image} alt={program.title} />
+            ) : (
+              <Placeholder className="d-flex justify-content-center align-items-center bg-secondary">
+                {program.title.charAt(0)}
+              </Placeholder>
+            )}
+            <div className="p-3">
+              <CardTitle className="mb-2">{program.title}</CardTitle>
+              <CardDescription className="mb-0">
+                {program.description}
+              </CardDescription>
+            </div>
+          </Card>
+        ))}
+      </Grid>
     </Container>
   )
 }


### PR DESCRIPTION
## Summary
- show a styled grid of training programs instead of plain text

## Testing
- `npm test` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687e8911bdc4832790bcb1eb31112347