### PR TITLE
Improve 404 page

### DIFF
--- a/WebsiteSalon/package.json
+++ b/WebsiteSalon/package.json
@@ -8,7 +8,7 @@
     "build": "vite build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "test": "vitest"
+    "test": "vitest",
     "format": "prettier --write ."
   },
   "dependencies": {

--- a/WebsiteSalon/src/assets/NotFound.svg
+++ b/WebsiteSalon/src/assets/NotFound.svg
@@ -1,0 +1,5 @@
+<svg width="300" height="200" viewBox="0 0 300 200" xmlns="http://www.w3.org/2000/svg">
+  <rect width="300" height="200" fill="#f8f9fa"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="80" fill="#dee2e6" font-family="Arial, Helvetica, sans-serif">404</text>
+  <path d="M150 120 l-30 30 m0 -30 l30 30" stroke="#adb5bd" stroke-width="8" stroke-linecap="round"/>
+</svg>

--- a/WebsiteSalon/src/components/NotFound.jsx
+++ b/WebsiteSalon/src/components/NotFound.jsx
@@ -1,8 +1,13 @@
 import React from 'react'
 import { Link } from 'react-router-dom'
+import notFoundImg from '../assets/NotFound.svg'
 
 const NotFound = () => (
-  <div className="d-flex flex-column align-items-center justify-content-center text-center py-5">
+  <div
+    className="d-flex flex-column align-items-center justify-content-center text-center py-5"
+    style={{ minHeight: '100vh', backgroundColor: '#f8f9fa' }}
+  >
+    <img src={notFoundImg} alt="Page not found" className="mb-4" style={{ maxWidth: '240px' }} />
     <h2 className="mb-3">404 - Page Not Found</h2>
     <p className="mb-4">The page you are looking for does not exist.</p>
     <Link to="/" className="btn btn-primary">Go Home</Link>

--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "main": "index.js",
   "scripts": {
     "cy:open": "cypress open",
-    "cy:run": "cypress run"
+    "cy:run": "cypress run",
     "test": "echo \"Error: no test specified\" && exit 1",
-    "dev": "concurrently \"npm run nodemon --prefix ExpressBackend\" \"npm run dev --prefix WebsiteUser\""
+    "dev": "concurrently \"npm run nodemon --prefix ExpressBackend\" \"npm run dev --prefix WebsiteUser\"",
     "prepare": "husky install"
   },
   "keywords": [],
@@ -15,8 +15,8 @@
   "license": "ISC",
   "type": "commonjs",
   "devDependencies": {
-    "cypress": "^14.5.2"
-    "concurrently": "^9.2.0"
+    "cypress": "^14.5.2",
+    "concurrently": "^9.2.0",
     "husky": "^9.1.7"
   }
 }


### PR DESCRIPTION
## Summary
- show a friendly illustration on the admin 404 page
- tidy package.json files so `vitest` can run

## Testing
- `node node_modules/vitest/dist/cli.js run`

------
https://chatgpt.com/codex/tasks/task_e_687e891a04bc8327978aa9f40f154dd4