### PR TITLE
Refactor auth forms to use react-hook-form

### DIFF
--- a/WebsiteUser/package-lock.json
+++ b/WebsiteUser/package-lock.json
@@ -23,6 +23,7 @@
         "react-bootstrap": "^2.10.9",
         "react-dom": "^19.0.0",
         "react-helmet": "^6.1.0",
+        "react-hook-form": "^7.60.0",
         "react-i18next": "^15.4.1",
         "react-icons": "^5.5.0",
         "react-leaflet": "^5.0.0",
@@ -3471,6 +3472,22 @@
       "integrity": "sha512-PVjOcvVOyIILrYoyGEpDN3vmYNLdy1CajSFNt4TDsVQC5KpTijDvWVoR+/7Rz2xT978D8/ZtFceXxzsPwZEDvw==",
       "peerDependencies": {
         "react": "^16.3.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/react-hook-form": {
+      "version": "7.60.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.60.0.tgz",
+      "integrity": "sha512-SBrYOvMbDB7cV8ZfNpaiLcgjH/a1c7aK0lK+aNigpf4xWLO8q+o4tcvVurv3c4EOyzn/3dCsYt4GKD42VvJ/+A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
       }
     },
     "node_modules/react-i18next": {

--- a/WebsiteUser/package.json
+++ b/WebsiteUser/package.json
@@ -8,7 +8,7 @@
     "build": "vite build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "test": "vitest"
+    "test": "vitest",
     "format": "prettier --write ."
   },
   "dependencies": {
@@ -27,6 +27,7 @@
     "react-bootstrap": "^2.10.9",
     "react-dom": "^19.0.0",
     "react-helmet": "^6.1.0",
+    "react-hook-form": "^7.60.0",
     "react-i18next": "^15.4.1",
     "react-icons": "^5.5.0",
     "react-leaflet": "^5.0.0",
@@ -34,18 +35,18 @@
     "styled-components": "^6.1.19"
   },
   "devDependencies": {
-    "@types/react": "^19.0.10",
-    "@types/react-dom": "^19.0.4",
-    "@vitejs/plugin-react": "^4.3.4",
     "@testing-library/jest-dom": "^6.4.0",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.0",
+    "@types/react": "^19.0.10",
+    "@types/react-dom": "^19.0.4",
+    "@vitejs/plugin-react": "^4.3.4",
     "autoprefixer": "^10.4.21",
     "globals": "^15.15.0",
+    "jsdom": "^24.0.0",
     "postcss": "^8.5.3",
     "tailwindcss": "^4.1.4",
     "vite": "^6.2.0",
-    "vitest": "^1.3.0",
-    "jsdom": "^24.0.0"
+    "vitest": "^1.3.0"
   }
 }

--- a/WebsiteUser/src/components/auth/Signin.jsx
+++ b/WebsiteUser/src/components/auth/Signin.jsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components'
 import TopBar from '../layout/TopBar'
-import PropTypes from 'prop-types'
 import useSignIn from '../../functionality/auth/UseSignIn'
+import { useForm } from 'react-hook-form'
 const Container = styled.div`
   max-width: 500px;
   margin: 5rem auto;
@@ -87,19 +87,15 @@ import { AppContext } from '../../context/AppContext'
 
 const SignIn = () => {
   const { setUser } = useContext(AppContext)
+  const { t, error, handleSignIn } = useSignIn()
   const {
-    t,
-    username,
-    setUsername,
-    password,
-    setPassword,
-    error,
-    handleSignIn
-  } = useSignIn()
+    register,
+    handleSubmit,
+    formState: { errors }
+  } = useForm()
 
-  const onSubmit = (e) => {
-    e.preventDefault()
-    handleSignIn()
+  const onSubmit = (data) => {
+    handleSignIn({ username: data.username, password: data.password })
   }
 
   return (
@@ -108,27 +104,25 @@ const SignIn = () => {
       <Container>
         <Heading>{t('Sign In')}</Heading>
 
-        <form onSubmit={onSubmit}>
+        <form onSubmit={handleSubmit(onSubmit)}>
           <FormGroup>
             <Label>{t('Username')}</Label>
             <Input
               type="text"
-              value={username}
-              onChange={(e) => setUsername(e.target.value)}
+              {...register('username', { required: t('Username is required') })}
               placeholder={t('Enter your username')}
-              required
             />
+            {errors.username && <ErrorText>{errors.username.message}</ErrorText>}
           </FormGroup>
 
           <FormGroup>
             <Label>{t('Password')}</Label>
             <Input
               type="password"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
+              {...register('password', { required: t('Password is required') })}
               placeholder={t('Enter your password')}
-              required
             />
+            {errors.password && <ErrorText>{errors.password.message}</ErrorText>}
           </FormGroup>
 
           {error && <ErrorText>{error}</ErrorText>}
@@ -143,10 +137,6 @@ const SignIn = () => {
       </Container>
     </>
   )
-}
-
-SignIn.propTypes = {
-  setUser: PropTypes.func.isRequired
 }
 
 export default SignIn

--- a/WebsiteUser/src/components/auth/Signup.jsx
+++ b/WebsiteUser/src/components/auth/Signup.jsx
@@ -1,6 +1,7 @@
 import styled from 'styled-components'
 import TopBar from '../layout/TopBar'
 import useSignUp from '../../functionality/auth/UseSignUp'
+import { useForm } from 'react-hook-form'
 
 const Container = styled.div`
   max-width: 500px;
@@ -83,23 +84,21 @@ const SignInLink = styled.a`
   }
 `
 const SignUp = () => {
+  const { t, error, handleSignUp } = useSignUp()
   const {
-    t,
-    email,
-    setEmail,
-    username,
-    setUsername,
-    password,
-    setPassword,
-    confirmPassword,
-    setConfirmPassword,
-    error,
-    handleSignUp
-  } = useSignUp()
+    register,
+    handleSubmit,
+    watch,
+    formState: { errors }
+  } = useForm()
 
-  const onSubmit = (e) => {
-    e.preventDefault()
-    handleSignUp()
+  const onSubmit = (data) => {
+    handleSignUp({
+      email: data.email,
+      username: data.username,
+      password: data.password,
+      confirmPassword: data.confirmPassword
+    })
   }
 
   return (
@@ -108,49 +107,51 @@ const SignUp = () => {
       <Container>
         <Heading>{t('Sign Up')}</Heading>
 
-        <form onSubmit={onSubmit}>
+        <form onSubmit={handleSubmit(onSubmit)}>
           <FormGroup>
             <Label>{t('Username')}</Label>
             <Input
               type="text"
-              value={username}
-              onChange={(e) => setUsername(e.target.value)}
+              {...register('username', { required: t('Username is required') })}
               placeholder={t('Enter your username')}
-              required
             />
+            {errors.username && <ErrorText>{errors.username.message}</ErrorText>}
           </FormGroup>
 
           <FormGroup>
             <Label>{t('Email Address')}</Label>
             <Input
               type="email"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
+              {...register('email', { required: t('Email is required') })}
               placeholder={t('Enter your email')}
-              required
             />
+            {errors.email && <ErrorText>{errors.email.message}</ErrorText>}
           </FormGroup>
 
           <FormGroup>
             <Label>{t('Password')}</Label>
             <Input
               type="password"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
+              {...register('password', { required: t('Password is required') })}
               placeholder={t('Enter your password')}
-              required
             />
+            {errors.password && <ErrorText>{errors.password.message}</ErrorText>}
           </FormGroup>
 
           <FormGroup>
             <Label>{t('Confirm Password')}</Label>
             <Input
               type="password"
-              value={confirmPassword}
-              onChange={(e) => setConfirmPassword(e.target.value)}
+              {...register('confirmPassword', {
+                required: t('Confirm Password is required'),
+                validate: (value) =>
+                  value === watch('password') || t('Passwords do not match')
+              })}
               placeholder={t('Confirm your password')}
-              required
             />
+            {errors.confirmPassword && (
+              <ErrorText>{errors.confirmPassword.message}</ErrorText>
+            )}
           </FormGroup>
 
           {error && <ErrorText>{error}</ErrorText>}

--- a/WebsiteUser/src/functionality/auth/UseSignIn.jsx
+++ b/WebsiteUser/src/functionality/auth/UseSignIn.jsx
@@ -8,11 +8,9 @@ const useSignIn = () => {
   const navigate = useNavigate()
   const { t } = useTranslation()
 
-  const [username, setUsername] = useState('')
-  const [password, setPassword] = useState('')
   const [error, setError] = useState('')
 
-  const handleSignIn = async () => {
+  const handleSignIn = async ({ username, password }) => {
     try {
       const res = await fetch(`${import.meta.env.VITE_API_URL}/users/login`, {
         method: 'POST',
@@ -39,10 +37,6 @@ const useSignIn = () => {
 
   return {
     t,
-    username,
-    setUsername,
-    password,
-    setPassword,
     error,
     handleSignIn
   }

--- a/WebsiteUser/src/functionality/auth/UseSignUp.jsx
+++ b/WebsiteUser/src/functionality/auth/UseSignUp.jsx
@@ -7,13 +7,9 @@ const useSignUp = () => {
   const navigate = useNavigate()
   const { t } = useTranslation()
 
-  const [email, setEmail] = useState('')
-  const [username, setUsername] = useState('')
-  const [password, setPassword] = useState('')
-  const [confirmPassword, setConfirmPassword] = useState('')
   const [error, setError] = useState('')
 
-  const handleSignUp = async () => {
+  const handleSignUp = async ({ email, username, password, confirmPassword }) => {
     if (!email || !username || !password || !confirmPassword) {
       setError(t('Please fill out all fields'))
       return
@@ -45,14 +41,6 @@ const useSignUp = () => {
 
   return {
     t,
-    email,
-    setEmail,
-    username,
-    setUsername,
-    password,
-    setPassword,
-    confirmPassword,
-    setConfirmPassword,
     error,
     setError,
     handleSignUp

--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "main": "index.js",
   "scripts": {
     "cy:open": "cypress open",
-    "cy:run": "cypress run"
+    "cy:run": "cypress run",
     "test": "echo \"Error: no test specified\" && exit 1",
-    "dev": "concurrently \"npm run nodemon --prefix ExpressBackend\" \"npm run dev --prefix WebsiteUser\""
+    "dev": "concurrently \"npm run nodemon --prefix ExpressBackend\" \"npm run dev --prefix WebsiteUser\"",
     "prepare": "husky install"
   },
   "keywords": [],
@@ -15,8 +15,8 @@
   "license": "ISC",
   "type": "commonjs",
   "devDependencies": {
-    "cypress": "^14.5.2"
-    "concurrently": "^9.2.0"
+    "cypress": "^14.5.2",
+    "concurrently": "^9.2.0",
     "husky": "^9.1.7"
   }
 }


### PR DESCRIPTION
## Summary
- install `react-hook-form`
- update root `package.json` syntax
- refactor `Signin.jsx` and `Signup.jsx` to use `react-hook-form`
- adapt sign-in and sign-up hooks for new parameters

## Testing
- `npm test --prefix WebsiteUser`


------
https://chatgpt.com/codex/tasks/task_e_687e891f35c48327b9d81f8fcfa38fe6