### PR TITLE
Add expandable service descriptions

### DIFF
--- a/WebsiteUser/package.json
+++ b/WebsiteUser/package.json
@@ -8,7 +8,7 @@
     "build": "vite build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "test": "vitest"
+    "test": "vitest",
     "format": "prettier --write ."
   },
   "dependencies": {

--- a/WebsiteUser/src/components/salons/SalonDetails.jsx
+++ b/WebsiteUser/src/components/salons/SalonDetails.jsx
@@ -1,5 +1,6 @@
 import { useParams, useNavigate } from 'react-router-dom'
 import { Spinner, Button } from 'react-bootstrap'
+import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { MapContainer, TileLayer, Marker } from 'react-leaflet'
 import 'leaflet/dist/leaflet.css'
@@ -21,9 +22,13 @@ const SalonDetails = () => {
   const { id } = useParams()
   const navigate = useNavigate()
   const { t } = useTranslation()
+  const [expanded, setExpanded] = useState({})
 
   const { salon, loading, error, retry, isMobile, latitude, longitude } =
     useSalonDetails(id)
+
+  const toggleExpanded = (sid) =>
+    setExpanded((prev) => ({ ...prev, [sid]: !prev[sid] }))
 
   if (loading) {
     return (
@@ -101,21 +106,45 @@ const SalonDetails = () => {
         {salon.services && salon.services.length > 0 ? (
           <div style={styles.servicesContainer}>
             <strong style={{ color: '#f0e68c' }}>{t('Services')}:</strong>
-            <div className="mt-2 d-flex flex-wrap gap-2">
-              {salon.services.map((service, i) => (
-                <span
-                  key={i}
-                  className="badge px-3 py-2"
-                  style={{
-                    borderRadius: '20px',
-                    backgroundColor: '#254d8f',
-                    color: '#f0f8ff',
-                    fontSize: '0.9rem'
-                  }}
-                >
-                  {t(service.name)}
-                </span>
-              ))}
+            <div className="mt-2 d-flex flex-column gap-2">
+              {salon.services.map((service) => {
+                const desc = service.description || ''
+                const isLong = desc.length > 100
+                const isOpen = expanded[service.id]
+                return (
+                  <div
+                    key={service.id}
+                    style={{
+                      borderRadius: '12px',
+                      backgroundColor: '#254d8f',
+                      color: '#f0f8ff',
+                      padding: '0.5rem 0.75rem'
+                    }}
+                  >
+                    <strong>{t(service.name)}</strong>
+                    {desc && (
+                      <p style={{ margin: '0.25rem 0 0', fontSize: '0.85rem' }}>
+                        {isOpen || !isLong ? desc : desc.slice(0, 100) + '...'}
+                        {isLong && (
+                          <button
+                            onClick={() => toggleExpanded(service.id)}
+                            style={{
+                              background: 'none',
+                              border: 'none',
+                              color: '#a3c1f7',
+                              marginLeft: '4px',
+                              cursor: 'pointer',
+                              padding: 0
+                            }}
+                          >
+                            {isOpen ? t('Show Less') : t('Show More')}
+                          </button>
+                        )}
+                      </p>
+                    )}
+                  </div>
+                )
+              })}
             </div>
           </div>
         ) : (

--- a/WebsiteUser/src/locales/ar/translation.json
+++ b/WebsiteUser/src/locales/ar/translation.json
@@ -137,6 +137,8 @@
   "Available": "المتوفر",
   "Adding": "الإضافة",
   "Add to Cart": "أضف إلى السلة",
+  "Show More": "المزيد",
+  "Show Less": "إظهار أقل",
   "no_packages_found": "لم يتم العثور على باقات",
   "Cart": "السلة",
   "Cart is empty": "السلة فارغة",

--- a/WebsiteUser/src/locales/en/translation.json
+++ b/WebsiteUser/src/locales/en/translation.json
@@ -137,6 +137,8 @@
   "Available": "Available",
   "Adding": "Adding",
   "Add to Cart": "Add to Cart",
+  "Show More": "Show More",
+  "Show Less": "Show Less",
   "no_packages_found": "No packages found",
   "Cart": "Cart",
   "Cart is empty": "Cart is empty",

--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "main": "index.js",
   "scripts": {
     "cy:open": "cypress open",
-    "cy:run": "cypress run"
+    "cy:run": "cypress run",
     "test": "echo \"Error: no test specified\" && exit 1",
-    "dev": "concurrently \"npm run nodemon --prefix ExpressBackend\" \"npm run dev --prefix WebsiteUser\""
+    "dev": "concurrently \"npm run nodemon --prefix ExpressBackend\" \"npm run dev --prefix WebsiteUser\"",
     "prepare": "husky install"
   },
   "keywords": [],
@@ -15,8 +15,8 @@
   "license": "ISC",
   "type": "commonjs",
   "devDependencies": {
-    "cypress": "^14.5.2"
-    "concurrently": "^9.2.0"
+    "cypress": "^14.5.2",
+    "concurrently": "^9.2.0",
     "husky": "^9.1.7"
   }
 }


### PR DESCRIPTION
## Summary
- allow toggling of long service descriptions in salon details
- include text for new buttons in translations
- fix malformed package.json files so tests run

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687e892683748327b10db7d8a50afe36