### PR TITLE
Add filtering to favorites list

### DIFF
--- a/WebsiteUser/src/components/products/Favorites.jsx
+++ b/WebsiteUser/src/components/products/Favorites.jsx
@@ -64,6 +64,9 @@ const Favorites = ({ userId, userType }) => {
   const [maxDistance, setMaxDistance] = useState(100)
   const [sortBy, setSortBy] = useState('distance')
   const [showFilters, setShowFilters] = useState(false)
+  const [categoryFilter, setCategoryFilter] = useState('')
+  const [minPrice, setMinPrice] = useState('')
+  const [maxPrice, setMaxPrice] = useState('')
 
   const { favorites, loading, error, toggleFavorite, retry } = useFavorites(
     userId,
@@ -89,11 +92,26 @@ const Favorites = ({ userId, userType }) => {
     )
   }
 
-  const filteredFavorites = favorites.filter((salon) => {
-    const meetsRating = salon.rating >= minRating
+  const categories = Array.from(
+    new Set(favorites.map((p) => p.category).filter(Boolean))
+  )
+
+  const filteredFavorites = favorites.filter((product) => {
+    const meetsCategory =
+      categoryFilter === '' || product.category === categoryFilter
+    const price = Number(product.price)
+    const meetsMinPrice =
+      minPrice === '' || (!isNaN(price) && price >= Number(minPrice))
+    const meetsMaxPrice =
+      maxPrice === '' || (!isNaN(price) && price <= Number(maxPrice))
+
+    const meetsRating = product.rating >= minRating
     const meetsDistance =
-      salon.distance !== null ? salon.distance <= maxDistance : false
-    return meetsRating && meetsDistance
+      product.distance !== null ? product.distance <= maxDistance : false
+
+    return (
+      meetsCategory && meetsMinPrice && meetsMaxPrice && meetsRating && meetsDistance
+    )
   })
 
   const sortedFavorites = [...filteredFavorites].sort((a, b) => {
@@ -182,6 +200,55 @@ const Favorites = ({ userId, userType }) => {
               min={0}
               value={maxDistance}
               onChange={(e) => setMaxDistance(Number(e.target.value))}
+            />
+          </div>
+
+          {categories.length > 0 && (
+            <div className="mb-3">
+              <label htmlFor="categoryFilter" className="form-label" style={{ color: '#ccc' }}>
+                {t('Category')}
+              </label>
+              <select
+                id="categoryFilter"
+                className="form-select"
+                value={categoryFilter}
+                onChange={(e) => setCategoryFilter(e.target.value)}
+              >
+                <option value="">{t('All')}</option>
+                {categories.map((cat) => (
+                  <option key={cat} value={cat}>
+                    {cat}
+                  </option>
+                ))}
+              </select>
+            </div>
+          )}
+
+          <div className="mb-3">
+            <label htmlFor="minPrice" className="form-label" style={{ color: '#ccc' }}>
+              {t('Min Price')}
+            </label>
+            <input
+              id="minPrice"
+              type="number"
+              className="form-control"
+              min={0}
+              value={minPrice}
+              onChange={(e) => setMinPrice(e.target.value)}
+            />
+          </div>
+
+          <div className="mb-3">
+            <label htmlFor="maxPrice" className="form-label" style={{ color: '#ccc' }}>
+              {t('Max Price')}
+            </label>
+            <input
+              id="maxPrice"
+              type="number"
+              className="form-control"
+              min={0}
+              value={maxPrice}
+              onChange={(e) => setMaxPrice(e.target.value)}
             />
           </div>
         </FilterContainer>


### PR DESCRIPTION
## Summary
- let users filter favorites by category or price range

## Testing
- `npx jest --coverage` *(fails: Cannot find module 'jest')*
- `npx cypress run` *(fails: needs to install cypress)*

------
https://chatgpt.com/codex/tasks/task_e_687e89287a488327bb1a28fe49c54b0e