### PR TITLE
Add icons to navigation links

### DIFF
--- a/WebsiteSalon/src/components/Navbar.jsx
+++ b/WebsiteSalon/src/components/Navbar.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react'
 import { Link } from 'react-router-dom'
+import { LayoutDashboard, CalendarCheck, User } from 'lucide-react'
 
 export default function Navbar() {
   const [isOpen, setIsOpen] = useState(false)
@@ -28,29 +29,29 @@ export default function Navbar() {
         <ul className="navbar-nav ms-auto">
           <li className="nav-item">
             <Link
-              className="nav-link"
+              className="nav-link d-flex align-items-center gap-1"
               to="/dashboard"
               onClick={() => setIsOpen(false)}
             >
-              Dashboard
+              <LayoutDashboard size={16} className="me-1" />Dashboard
             </Link>
           </li>
           <li className="nav-item">
             <Link
-              className="nav-link"
+              className="nav-link d-flex align-items-center gap-1"
               to="/bookings"
               onClick={() => setIsOpen(false)}
             >
-              Bookings
+              <CalendarCheck size={16} className="me-1" />Bookings
             </Link>
           </li>
           <li className="nav-item">
             <Link
-              className="nav-link"
+              className="nav-link d-flex align-items-center gap-1"
               to="/profile"
               onClick={() => setIsOpen(false)}
             >
-              Profile
+              <User size={16} className="me-1" />Profile
             </Link>
           </li>
         </ul>

--- a/WebsiteUser/src/components/layout/Navbar.jsx
+++ b/WebsiteUser/src/components/layout/Navbar.jsx
@@ -1,6 +1,16 @@
 import Dropdown from 'react-bootstrap/Dropdown'
 import { Link } from 'react-router-dom'
 import PropTypes from 'prop-types'
+import {
+  MapPin,
+  CalendarCheck,
+  ShoppingBag,
+  Package,
+  Heart,
+  Info,
+  Mail,
+  GraduationCap
+} from 'lucide-react'
 import useNavbar from '../../functionality/layout/UseNavbar'
 const Navbar = ({ setUserType, userType, user }) => {
   const {
@@ -14,6 +24,17 @@ const Navbar = ({ setUserType, userType, user }) => {
     navLinks,
     location
   } = useNavbar({ userType, setUserType })
+
+  const iconMap = {
+    '/': MapPin,
+    '/bookings': CalendarCheck,
+    '/products': ShoppingBag,
+    '/packages': Package,
+    '/favorites': Heart,
+    '/about': Info,
+    '/contact': Mail,
+    '/training': GraduationCap
+  }
 
   return (
     <>
@@ -234,17 +255,19 @@ const Navbar = ({ setUserType, userType, user }) => {
             tabIndex={0}
             aria-roledescription="scrollable list"
           >
-            {navLinks.map(({ to, label }, idx) => (
-              <Link
-                key={idx}
-                to={to}
-                className="btn btn-outline-primary btn-sm text-capitalize fw-semibold px-3"
-                style={{
-                  minWidth: 110,
-                  maxWidth: 110,
-                  fontSize: '0.95rem',
-                  borderRadius: '0.5rem',
-                  borderColor: '#4f8ef7',
+            {navLinks.map(({ to, label }, idx) => {
+              const Icon = iconMap[to]
+              return (
+                <Link
+                  key={idx}
+                  to={to}
+                  className="btn btn-outline-primary btn-sm text-capitalize fw-semibold px-3"
+                  style={{
+                    minWidth: 110,
+                    maxWidth: 110,
+                    fontSize: '0.95rem',
+                    borderRadius: '0.5rem',
+                    borderColor: '#4f8ef7',
                   whiteSpace: 'normal',
                   height: 70,
                   display: 'flex',
@@ -261,11 +284,13 @@ const Navbar = ({ setUserType, userType, user }) => {
                     location.pathname === to ? '#4f8ef7' : 'transparent',
                   color: location.pathname === to ? '#fff' : '#4f8ef7'
                 }}
-                aria-current={location.pathname === to ? 'page' : undefined}
-              >
-                {t(label)}
-              </Link>
-            ))}
+                  aria-current={location.pathname === to ? 'page' : undefined}
+                >
+                  {Icon && <Icon size={16} className="me-1" />}
+                  {t(label)}
+                </Link>
+              )
+            })}
           </div>
         </div>
       </nav>


### PR DESCRIPTION
## Summary
- add icon imports and mapping in WebsiteUser Navbar
- display icons next to admin nav links in WebsiteSalon

## Testing
- `npm test` (fails: invalid package.json)
- `npm test` in WebsiteUser (fails: invalid package.json)

------
https://chatgpt.com/codex/tasks/task_e_687e89296f708327bf173287b946b64b