### PR TITLE
Add opening hours to SalonDetails

### DIFF
--- a/WebsiteUser/package.json
+++ b/WebsiteUser/package.json
@@ -8,7 +8,7 @@
     "build": "vite build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "test": "vitest"
+    "test": "vitest",
     "format": "prettier --write ."
   },
   "dependencies": {

--- a/WebsiteUser/src/components/salons/SalonDetails.jsx
+++ b/WebsiteUser/src/components/salons/SalonDetails.jsx
@@ -98,6 +98,24 @@ const SalonDetails = () => {
           <span style={{ color: '#ddd' }}>{salon.rating} ⭐</span>
         </div>
 
+        <div style={styles.detailRow}>
+          <strong style={{ color: '#f0e68c' }}>{t('Address')}:</strong>{' '}
+          <span style={{ color: '#ddd' }}>
+            {latitude && longitude
+              ? `${latitude.toFixed(5)}, ${longitude.toFixed(5)}`
+              : t('N/A')}
+          </span>
+        </div>
+
+        {salon.opening_time && salon.closing_time && (
+          <div style={styles.detailRow}>
+            <strong style={{ color: '#f0e68c' }}>{t('Opening Hours')}:</strong>{' '}
+            <span style={{ color: '#ddd' }}>
+              {salon.opening_time.slice(0, 5)} - {salon.closing_time.slice(0, 5)}
+            </span>
+          </div>
+        )}
+
         {salon.services && salon.services.length > 0 ? (
           <div style={styles.servicesContainer}>
             <strong style={{ color: '#f0e68c' }}>{t('Services')}:</strong>

--- a/WebsiteUser/src/locales/ar/translation.json
+++ b/WebsiteUser/src/locales/ar/translation.json
@@ -61,6 +61,8 @@
   "No services available": "لا توجد خدمات متاحة",
   "Book Now": "احجز الآن",
   "Salon not found": "لم يتم العثور على الصالون",
+  "Address": "العنوان",
+  "Opening Hours": "ساعات العمل",
   "Failed to load salon data": "فشل في تحميل بيانات الصالون",
   "Please select a date and time": "يرجى تحديد التاريخ والوقت",
   "Please select at least one service": "يرجى تحديد خدمة واحدة على الأقل",

--- a/WebsiteUser/src/locales/en/translation.json
+++ b/WebsiteUser/src/locales/en/translation.json
@@ -61,6 +61,8 @@
   "No services available": "No services available",
   "Book Now": "Book Now",
   "Salon not found": "Salon not found",
+  "Address": "Address",
+  "Opening Hours": "Opening Hours",
   "Failed to load salon data": "Failed to load salon data",
   "Please select a date and time": "Please select a date and time",
   "Please select at least one service": "Please select at least one service",

--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "main": "index.js",
   "scripts": {
     "cy:open": "cypress open",
-    "cy:run": "cypress run"
+    "cy:run": "cypress run",
     "test": "echo \"Error: no test specified\" && exit 1",
-    "dev": "concurrently \"npm run nodemon --prefix ExpressBackend\" \"npm run dev --prefix WebsiteUser\""
+    "dev": "concurrently \"npm run nodemon --prefix ExpressBackend\" \"npm run dev --prefix WebsiteUser\"",
     "prepare": "husky install"
   },
   "keywords": [],
@@ -15,8 +15,8 @@
   "license": "ISC",
   "type": "commonjs",
   "devDependencies": {
-    "cypress": "^14.5.2"
-    "concurrently": "^9.2.0"
+    "cypress": "^14.5.2",
+    "concurrently": "^9.2.0",
     "husky": "^9.1.7"
   }
 }


### PR DESCRIPTION
## Summary
- show address coordinates and opening hours on the salon details page
- add translation strings for address and opening hours
- fix missing commas in package.json files

## Testing
- `npm run test --prefix WebsiteUser`


------
https://chatgpt.com/codex/tasks/task_e_687e8930d61883279b62229995dfd849