### PR TITLE
Add breakpoints and responsive styles

### DIFF
--- a/WebsiteUser/src/components/layout/TopBar.jsx
+++ b/WebsiteUser/src/components/layout/TopBar.jsx
@@ -13,6 +13,11 @@ const Container = styled.div`
   justify-content: space-between;
   align-items: center;
   z-index: 1;
+
+  @media (max-width: var(--breakpoint-sm)) {
+    flex-direction: column;
+    gap: 0.5rem;
+  }
 `
 
 const BackButton = styled.button`
@@ -44,6 +49,11 @@ const LangButton = styled.button`
   &:hover {
     background: #4f8ef7;
     color: #fff;
+  }
+
+  @media (max-width: var(--breakpoint-sm)) {
+    font-size: 0.85rem;
+    padding: 0.3rem 0.6rem;
   }
 `
 

--- a/WebsiteUser/src/components/products/Training.jsx
+++ b/WebsiteUser/src/components/products/Training.jsx
@@ -5,6 +5,10 @@ import Navbar from '../layout/Navbar'
 
 const Container = styled.div`
   padding: 1rem;
+
+  @media (min-width: var(--breakpoint-md)) {
+    padding: 2rem;
+  }
 `
 
 const HeaderRow = styled.div`
@@ -12,12 +16,22 @@ const HeaderRow = styled.div`
   justify-content: space-between;
   align-items: center;
   margin-bottom: 0.5rem;
+
+  @media (max-width: var(--breakpoint-sm)) {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.5rem;
+  }
 `
 
 const Title = styled.h6`
   font-weight: 700;
   margin: 0;
   color: #f0f8ff;
+
+  @media (max-width: var(--breakpoint-sm)) {
+    font-size: 1rem;
+  }
 `
 
 const FilterButton = styled.button`
@@ -34,6 +48,11 @@ const FilterButton = styled.button`
     background: #4f8ef7;
     color: #fff;
     border-color: #4f8ef7;
+  }
+
+  @media (max-width: var(--breakpoint-sm)) {
+    padding: 0.2rem 0.5rem;
+    font-size: 0.8rem;
   }
 `
 

--- a/WebsiteUser/src/main.jsx
+++ b/WebsiteUser/src/main.jsx
@@ -5,6 +5,7 @@ import ErrorBoundary from './ErrorBoundary.jsx'
 import { BrowserRouter } from 'react-router-dom'
 import { AppProvider } from './context/AppContext'
 import './i18n'
+import './styles/breakpoints.css'
 
 createRoot(document.getElementById('root')).render(
   <BrowserRouter>

--- a/WebsiteUser/src/styles/breakpoints.css
+++ b/WebsiteUser/src/styles/breakpoints.css
@@ -1,0 +1,6 @@
+:root {
+  --breakpoint-sm: 576px;
+  --breakpoint-md: 768px;
+  --breakpoint-lg: 992px;
+  --breakpoint-xl: 1200px;
+}


### PR DESCRIPTION
## Summary
- define CSS custom properties for breakpoints
- include breakpoints globally
- apply responsive rules in `TopBar` and `Training` components

## Testing
- `npm test --prefix WebsiteUser` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687e8935049c832799a94f6657367912