### PR TITLE
Improve SEO meta descriptions

### DIFF
--- a/WebsiteUser/package.json
+++ b/WebsiteUser/package.json
@@ -8,7 +8,7 @@
     "build": "vite build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "test": "vitest"
+    "test": "vitest",
     "format": "prettier --write ."
   },
   "dependencies": {

--- a/WebsiteUser/src/components/About.jsx
+++ b/WebsiteUser/src/components/About.jsx
@@ -1,7 +1,15 @@
 import React from 'react'
+import { Helmet } from 'react-helmet'
 
 const About = () => (
   <div className="container text-light py-5 text-center">
+    <Helmet>
+      <title>About MySalon</title>
+      <meta
+        name="description"
+        content="Learn more about MySalon and our commitment to premium beauty services."
+      />
+    </Helmet>
     <h2 className="mb-3">About MySalon</h2>
     <p className="lead">
       MySalon brings modern style and professional care together under one roof.

--- a/WebsiteUser/src/components/NotFound.jsx
+++ b/WebsiteUser/src/components/NotFound.jsx
@@ -1,8 +1,16 @@
 import React from 'react'
 import { Link } from 'react-router-dom'
+import { Helmet } from 'react-helmet'
 
 const NotFound = () => (
   <div className="d-flex flex-column align-items-center justify-content-center text-center py-5">
+    <Helmet>
+      <title>Page Not Found</title>
+      <meta
+        name="description"
+        content="The page you requested could not be found on MySalon."
+      />
+    </Helmet>
     <h2 className="mb-3">404 - Page Not Found</h2>
     <p className="mb-4">The page you are looking for does not exist.</p>
     <Link to="/" className="btn btn-primary">Go Home</Link>

--- a/WebsiteUser/src/components/ServerError.jsx
+++ b/WebsiteUser/src/components/ServerError.jsx
@@ -1,7 +1,15 @@
 import React from 'react'
+import { Helmet } from 'react-helmet'
 
 const ServerError = ({ onRetry }) => (
   <div className="d-flex flex-column align-items-center justify-content-center text-center py-5">
+    <Helmet>
+      <title>Server Error</title>
+      <meta
+        name="description"
+        content="An unexpected error occurred on MySalon. Please try again."
+      />
+    </Helmet>
     <h2 className="mb-3">Server Error</h2>
     <p className="mb-4">Something went wrong on our end. Please try again.</p>
     {onRetry && (

--- a/WebsiteUser/src/components/contact/ContactUs.jsx
+++ b/WebsiteUser/src/components/contact/ContactUs.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import { Helmet } from 'react-helmet'
 import { API_URL } from '../../config'
 
 const ContactUs = () => {
@@ -33,6 +34,13 @@ const ContactUs = () => {
 
   return (
     <div className="container py-5">
+      <Helmet>
+        <title>{t('Contact Us')}</title>
+        <meta
+          name="description"
+          content="Get in touch with the MySalon team. We'd love to hear from you."
+        />
+      </Helmet>
       <h2 className="text-center mb-4">{t('Contact Us')}</h2>
       <form onSubmit={handleSubmit} className="mx-auto" style={{ maxWidth: 500 }}>
         <div className="mb-3">

--- a/WebsiteUser/src/components/orders/BookingDetailsPage.jsx
+++ b/WebsiteUser/src/components/orders/BookingDetailsPage.jsx
@@ -122,13 +122,17 @@ const BookingDetailsPage = () => {
     )
   }
 
-  return (
-    <Container>
-      <Helmet>
-        <title>{`${t('Booking')} #${booking.id || t('Unknown')} ${t(
-          'Details'
-        )}`}</title>
-      </Helmet>
+    return (
+      <Container>
+        <Helmet>
+          <title>{`${t('Booking')} #${booking.id || t('Unknown')} ${t(
+            'Details'
+          )}`}</title>
+          <meta
+            name="description"
+            content="Detailed view of your booking at MySalon."
+          />
+        </Helmet>
 
       <Card>
         <Title>

--- a/WebsiteUser/src/components/orders/MyBookings.jsx
+++ b/WebsiteUser/src/components/orders/MyBookings.jsx
@@ -102,6 +102,10 @@ const MyBookings = () => {
       <Container className="container mt-5 text-center">
         <Helmet>
           <title>{t('My Bookings & Orders')}</title>
+          <meta
+            name="description"
+            content="Review your salon bookings and product orders with MySalon."
+          />
         </Helmet>
         <Header>{t('Access Restricted')}</Header>
         <p className="text-center text-danger mt-5">
@@ -138,6 +142,10 @@ const MyBookings = () => {
     <Container className="container mt-4">
       <Helmet>
         <title>{t('My Bookings & Orders')}</title>
+        <meta
+          name="description"
+          content="Review your salon bookings and product orders with MySalon."
+        />
       </Helmet>
 
       <Header className="text-center mb-4">

--- a/WebsiteUser/src/components/orders/OrderDetailsPage.jsx
+++ b/WebsiteUser/src/components/orders/OrderDetailsPage.jsx
@@ -178,13 +178,17 @@ const OrderDetailsPage = () => {
     )
   }
 
-  return (
-    <Container>
-      <Helmet>
-        <title>{`${t('Order')} #${order.id || t('Unknown')} ${t(
-          'Details'
-        )}`}</title>
-      </Helmet>
+    return (
+      <Container>
+        <Helmet>
+          <title>{`${t('Order')} #${order.id || t('Unknown')} ${t(
+            'Details'
+          )}`}</title>
+          <meta
+            name="description"
+            content="Detailed view of your order at MySalon."
+          />
+        </Helmet>
 
       <Card>
         <Heading>

--- a/WebsiteUser/src/components/products/Favorites.jsx
+++ b/WebsiteUser/src/components/products/Favorites.jsx
@@ -107,11 +107,15 @@ const Favorites = ({ userId, userType }) => {
     return 0
   })
 
-  return (
-    <Container className="container mt-4">
-      <Helmet>
-        <title>{t('Favorites')}</title>
-      </Helmet>
+    return (
+      <Container className="container mt-4">
+        <Helmet>
+          <title>{t('Favorites')}</title>
+          <meta
+            name="description"
+            content="Your saved salons and products at MySalon."
+          />
+        </Helmet>
 
       <Header className="text-center mb-4"> {t('Favorites')} </Header>
 

--- a/WebsiteUser/src/components/products/Packages.jsx
+++ b/WebsiteUser/src/components/products/Packages.jsx
@@ -22,11 +22,15 @@ const Packages = () => {
     handleAddToCart
   } = usePackages(t)
 
-  return (
-    <div className="container mt-4" style={{ color: '#ddd' }}>
-      <Helmet>
-        <title>{t('Packages')}</title>
-      </Helmet>
+    return (
+      <div className="container mt-4" style={{ color: '#ddd' }}>
+        <Helmet>
+          <title>{t('Packages')}</title>
+          <meta
+            name="description"
+            content="Check out special packages and offers from MySalon."
+          />
+        </Helmet>
 
       <h2
         className="text-center mb-4"

--- a/WebsiteUser/src/components/products/Products.jsx
+++ b/WebsiteUser/src/components/products/Products.jsx
@@ -104,11 +104,15 @@ const Products = () => {
     )
   }
 
-  return (
-    <Container className="container mt-4">
-      <Helmet>
-        <title>{t('Products')}</title>
-      </Helmet>
+    return (
+      <Container className="container mt-4">
+        <Helmet>
+          <title>{t('Products')}</title>
+          <meta
+            name="description"
+            content="Browse our range of beauty products available at MySalon."
+          />
+        </Helmet>
 
       <Header className="text-center mb-4"> {t('Products')} </Header>
 

--- a/WebsiteUser/src/components/products/Training.jsx
+++ b/WebsiteUser/src/components/products/Training.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import { Helmet } from 'react-helmet'
 import styled from 'styled-components'
 import Navbar from '../layout/Navbar'
 
@@ -43,6 +44,13 @@ const Training = () => {
 
   return (
     <Container>
+      <Helmet>
+        <title>{t('training')}</title>
+        <meta
+          name="description"
+          content="Explore training sessions and tutorials provided by MySalon."
+        />
+      </Helmet>
       <Navbar />
       <HeaderRow>
         <Title>{t('training')}</Title>

--- a/WebsiteUser/src/components/salons/NearestSalon.jsx
+++ b/WebsiteUser/src/components/salons/NearestSalon.jsx
@@ -115,11 +115,15 @@ const NearestSalon = ({ userType, userId }) => {
     return 0
   })
 
-  return (
-    <Container className="container mt-4">
-      <Helmet>
-        <title>{t('Nearest Salons')}</title>
-      </Helmet>
+    return (
+      <Container className="container mt-4">
+        <Helmet>
+          <title>{t('Nearest Salons')}</title>
+          <meta
+            name="description"
+            content="Find salons closest to you and book an appointment."
+          />
+        </Helmet>
 
       <Header className="text-center mb-4"> {t('Nearest Salons')} </Header>
 

--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "main": "index.js",
   "scripts": {
     "cy:open": "cypress open",
-    "cy:run": "cypress run"
+    "cy:run": "cypress run",
     "test": "echo \"Error: no test specified\" && exit 1",
-    "dev": "concurrently \"npm run nodemon --prefix ExpressBackend\" \"npm run dev --prefix WebsiteUser\""
+    "dev": "concurrently \"npm run nodemon --prefix ExpressBackend\" \"npm run dev --prefix WebsiteUser\"",
     "prepare": "husky install"
   },
   "keywords": [],
@@ -15,8 +15,8 @@
   "license": "ISC",
   "type": "commonjs",
   "devDependencies": {
-    "cypress": "^14.5.2"
-    "concurrently": "^9.2.0"
+    "cypress": "^14.5.2",
+    "concurrently": "^9.2.0",
     "husky": "^9.1.7"
   }
 }


### PR DESCRIPTION
## Summary
- add Helmet for About page and other pages in WebsiteUser
- include meta description for pages already using Helmet
- add SEO details for Contact, NotFound, and ServerError pages
- fix invalid JSON in package.json files

## Testing
- `npm install --prefix WebsiteUser`
- `npm test --prefix WebsiteUser`

------
https://chatgpt.com/codex/tasks/task_e_687e8939e2e08327ab00628ca333216f