### PR TITLE
Add sorting dropdown for packages

### DIFF
--- a/WebsiteUser/src/components/products/Packages.jsx
+++ b/WebsiteUser/src/components/products/Packages.jsx
@@ -67,22 +67,17 @@ const Packages = () => {
           <i className="bi bi-funnel-fill me-1"></i> {t('Filters')}
         </button>
         {showFilters && (
-          <div className="d-flex flex-wrap gap-2 mb-2">
-            {['priceHigh', 'priceLow', 'name'].map((option) => (
-              <button
-                key={option}
-                onClick={() => handleSort(option)}
-                className={`btn btn-sm ${
-                  sortOption === option
-                    ? 'btn-primary'
-                    : 'btn-outline-secondary'
-                }`}
-              >
-                {option === 'priceHigh' && t('High to low')}
-                {option === 'priceLow' && t('Low to high')}
-                {option === 'name' && t('A-Z')}
-              </button>
-            ))}
+          <div className="mb-2" style={{ minWidth: 160 }}>
+            <select
+              className="form-select form-select-sm"
+              value={sortOption}
+              onChange={(e) => handleSort(e.target.value)}
+            >
+              <option value="">{t('Filters')}</option>
+              <option value="priceHigh">{t('High to low')}</option>
+              <option value="priceLow">{t('Low to high')}</option>
+              <option value="newest">{t('Newest')}</option>
+            </select>
           </div>
         )}
       </div>

--- a/WebsiteUser/src/functionality/products/UsePackages.jsx
+++ b/WebsiteUser/src/functionality/products/UsePackages.jsx
@@ -33,6 +33,13 @@ export default function usePackages(t) {
       return sorted.sort((a, b) => a.price - b.price)
     if (sortOption === 'name')
       return sorted.sort((a, b) => a.name.localeCompare(b.name))
+    if (sortOption === 'newest')
+      return sorted.sort((a, b) => {
+        const dateA = new Date(a.created_at || a.createdAt || 0)
+        const dateB = new Date(b.created_at || b.createdAt || 0)
+        if (isNaN(dateA) || isNaN(dateB)) return b.id - a.id
+        return dateB - dateA
+      })
     return sorted
   }
 

--- a/WebsiteUser/src/locales/ar/translation.json
+++ b/WebsiteUser/src/locales/ar/translation.json
@@ -129,6 +129,7 @@
   "no_products_found": "لم يتم العثور على منتجات",
   "High to low": "من الأعلى إلى الأقل",
   "Low to high": "من الأقل إلى الأعلى",
+  "Newest": "الأحدث",
   "A-Z": "أ-ي",
   "Not enough stock available": "لا يوجد مخزون كافٍ",
   "added to cart": "تمت الإضافة إلى السلة",

--- a/WebsiteUser/src/locales/en/translation.json
+++ b/WebsiteUser/src/locales/en/translation.json
@@ -129,6 +129,7 @@
   "no_products_found": "No products found",
   "High to low": "High to low",
   "Low to high": "Low to high",
+  "Newest": "Newest",
   "A-Z": "A-Z",
   "Not enough stock available": "Not enough stock available",
   "added to cart": "added to cart",


### PR DESCRIPTION
## Summary
- add "newest" sorting in usePackages hook
- expose dropdown select in `Packages.jsx` for sort options
- update translations for new "Newest" label

## Testing
- `npm test --prefix WebsiteUser` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687e893f5e988327a523080e0f9b0fcc