### PR TITLE
Apply alternating backgrounds

### DIFF
--- a/WebsiteUser/package.json
+++ b/WebsiteUser/package.json
@@ -8,7 +8,7 @@
     "build": "vite build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "test": "vitest"
+    "test": "vitest",
     "format": "prettier --write ."
   },
   "dependencies": {

--- a/WebsiteUser/src/components/orders/MyBookings.jsx
+++ b/WebsiteUser/src/components/orders/MyBookings.jsx
@@ -57,6 +57,25 @@ const Status = styled.div`
       : '#ccc'};
 `
 
+const ItemList = styled.ul`
+  list-style: none;
+  padding-left: 0;
+  margin-left: 0;
+`
+
+const ItemRow = styled.li`
+  display: flex;
+  align-items: center;
+  padding: 4px;
+  border-radius: 8px;
+  margin-bottom: 4px;
+  background-color: #2a2a2a;
+
+  &:nth-child(even) {
+    background-color: #252525;
+  }
+`
+
 const MyBookings = () => {
   const { t } = useTranslation()
   const navigate = useNavigate()
@@ -226,12 +245,9 @@ const MyBookings = () => {
                   {item.type === 'order' && (
                     <div className="mb-2">
                       <span className="text-secondary">{t('Items')}:</span>
-                      <ul className="list-unstyled ms-2 mt-1">
+                      <ItemList className="ms-2 mt-1">
                         {groupOrderItems(item.items).map((itm, i) => (
-                          <li
-                            key={i}
-                            className="mb-1 d-flex align-items-center"
-                          >
+                          <ItemRow key={i}>
                             {itm.image_url && (
                               <OrderItemImage
                                 src={itm.image_url}
@@ -247,9 +263,9 @@ const MyBookings = () => {
                                 BHD
                               </div>
                             </div>
-                          </li>
+                          </ItemRow>
                         ))}
-                      </ul>
+                      </ItemList>
                     </div>
                   )}
 

--- a/WebsiteUser/src/components/orders/OrderDetailsPage.jsx
+++ b/WebsiteUser/src/components/orders/OrderDetailsPage.jsx
@@ -55,6 +55,10 @@ const Item = styled.li`
   padding: 10px;
   border-radius: 10px;
   margin-bottom: 0.75rem;
+
+  &:nth-child(even) {
+    background-color: #252525;
+  }
 `
 
 const ItemImage = styled.img`

--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "main": "index.js",
   "scripts": {
     "cy:open": "cypress open",
-    "cy:run": "cypress run"
+    "cy:run": "cypress run",
     "test": "echo \"Error: no test specified\" && exit 1",
-    "dev": "concurrently \"npm run nodemon --prefix ExpressBackend\" \"npm run dev --prefix WebsiteUser\""
+    "dev": "concurrently \"npm run nodemon --prefix ExpressBackend\" \"npm run dev --prefix WebsiteUser\"",
     "prepare": "husky install"
   },
   "keywords": [],
@@ -15,8 +15,8 @@
   "license": "ISC",
   "type": "commonjs",
   "devDependencies": {
-    "cypress": "^14.5.2"
-    "concurrently": "^9.2.0"
+    "cypress": "^14.5.2",
+    "concurrently": "^9.2.0",
     "husky": "^9.1.7"
   }
 }


### PR DESCRIPTION
## Summary
- alternate background color for order/bookings lists
- ensure package.json files parse correctly

## Testing
- `npm test --prefix WebsiteUser`

------
https://chatgpt.com/codex/tasks/task_e_687e89402fa48327a7b7d9c04bc5a26e