### PR TITLE
Add focus outline styles for forms

### DIFF
--- a/WebsiteAdmin/src/App.css
+++ b/WebsiteAdmin/src/App.css
@@ -4,6 +4,16 @@
   box-sizing: border-box;
 }
 
+:root {
+  --primary-color: #f5277e;
+}
+
+input:focus,
+button:focus {
+  outline: 2px solid var(--primary-color);
+  outline-offset: 2px;
+}
+
 html,
 body,
 #root {

--- a/WebsiteSalon/src/App.css
+++ b/WebsiteSalon/src/App.css
@@ -1,0 +1,10 @@
+:root {
+  --primary-color: #f5277e;
+}
+
+input:focus,
+button:focus {
+  outline: 2px solid var(--primary-color);
+  outline-offset: 2px;
+}
+

--- a/WebsiteSalon/src/main.jsx
+++ b/WebsiteSalon/src/main.jsx
@@ -5,6 +5,7 @@ import { BrowserRouter } from 'react-router-dom'
 import App from './App'
 import { AuthProvider } from './context/AuthContext'
 import ErrorBoundary from './ErrorBoundary.jsx'
+import './App.css'
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <BrowserRouter>

--- a/WebsiteUser/src/App.css
+++ b/WebsiteUser/src/App.css
@@ -1,0 +1,10 @@
+:root {
+  --primary-color: #f5277e;
+}
+
+input:focus,
+button:focus {
+  outline: 2px solid var(--primary-color);
+  outline-offset: 2px;
+}
+

--- a/WebsiteUser/src/main.jsx
+++ b/WebsiteUser/src/main.jsx
@@ -5,6 +5,7 @@ import ErrorBoundary from './ErrorBoundary.jsx'
 import { BrowserRouter } from 'react-router-dom'
 import { AppProvider } from './context/AppContext'
 import './i18n'
+import './App.css'
 
 createRoot(document.getElementById('root')).render(
   <BrowserRouter>


### PR DESCRIPTION
## Summary
- style focused inputs and buttons using the primary color
- load App.css in the website bundles

## Testing
- `npm test --prefix ExpressBackend` *(fails: Invalid package.json)*
- `npm test --prefix WebsiteAdmin` *(fails: Invalid package.json)*
- `npm test --prefix WebsiteSalon` *(fails: Invalid package.json)*
- `npm test --prefix WebsiteUser` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687e894509288327b52a658a26066c87