### PR TITLE
Add clear filters option

### DIFF
--- a/WebsiteUser/src/components/products/Products.jsx
+++ b/WebsiteUser/src/components/products/Products.jsx
@@ -111,6 +111,12 @@ const Products = () => {
     handleAddToCart,
   } = useProducts(t)
 
+  const clearFilters = () => {
+    setSearchTerm('')
+    handleSort('')
+    setShowFilters(false)
+  }
+
   const showCheckmark = (id) => {
     setAddedIds((prev) => [...prev, id])
     setTimeout(
@@ -173,13 +179,21 @@ const Products = () => {
       </div>
 
       <div className="d-flex justify-content-between align-items-center mb-3 flex-wrap">
-        <button
-          className="btn btn-outline-primary btn-sm mb-2"
-          onClick={() => setShowFilters(!showFilters)}
-          aria-expanded={showFilters}
-        >
-          <i className="bi bi-funnel-fill me-1"></i> {t('Filters')}
-        </button>
+        <div className="d-flex gap-2 mb-2">
+          <button
+            className="btn btn-outline-primary btn-sm"
+            onClick={() => setShowFilters(!showFilters)}
+            aria-expanded={showFilters}
+          >
+            <i className="bi bi-funnel-fill me-1"></i> {t('Filters')}
+          </button>
+          <button
+            className="btn btn-outline-secondary btn-sm"
+            onClick={clearFilters}
+          >
+            <i className="bi bi-x-circle me-1"></i> {t('Clear Filters')}
+          </button>
+        </div>
         {showFilters && (
           <div className="d-flex flex-wrap gap-2 mb-2">
             {['priceHigh', 'priceLow', 'name'].map((option) => (

--- a/WebsiteUser/src/locales/ar/translation.json
+++ b/WebsiteUser/src/locales/ar/translation.json
@@ -137,6 +137,7 @@
   "Newest": "الأحدث",
   "A-Z": "أ-ي",
   "Search products": "ابحث عن المنتجات",
+  "Clear Filters": "مسح الفلاتر",
   "Not enough stock available": "لا يوجد مخزون كافٍ",
   "added to cart": "تمت الإضافة إلى السلة",
   "Failed to update quantity": "فشل في تحديث الكمية",

--- a/WebsiteUser/src/locales/en/translation.json
+++ b/WebsiteUser/src/locales/en/translation.json
@@ -137,6 +137,7 @@
   "Newest": "Newest",
   "A-Z": "A-Z",
   "Search products": "Search products",
+  "Clear Filters": "Clear Filters",
   "Not enough stock available": "Not enough stock available",
   "added to cart": "added to cart",
   "Failed to update quantity": "Failed to update quantity",


### PR DESCRIPTION
## Summary
- reset product search and sorting with new `clearFilters`
- add Clear Filters button next to Filters
- include translations for Clear Filters in English and Arabic

## Testing
- `npm test --prefix WebsiteUser` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_68836908d2988327b52d6d3d0d2fe8eb