### PR TITLE
Add cookie consent banner

### DIFF
--- a/WebsiteUser/src/App.jsx
+++ b/WebsiteUser/src/App.jsx
@@ -49,6 +49,7 @@ import Privacy from './components/legal/Privacy';
 import backgroundImage from './assets/Background.png';
 import { AppContext } from './context/AppContext';
 import ScrollToTop from './components/ScrollToTop';
+import CookieConsent from './components/CookieConsent';
 
 const App = () => {
   const location = useLocation();
@@ -93,24 +94,42 @@ const App = () => {
               exit={{ opacity: 0 }}
             >
               <Routes>
-                <Route path="/" element={<NearestSalon userType={userType} userId={userId} />} />
-                <Route path="/salon/:id" element={<SalonDetails userId={userId} />} />
-                <Route path="/salon/:id/book" element={<SalonBooking userId={userId} />} />
+                <Route
+                  path="/"
+                  element={<NearestSalon userType={userType} userId={userId} />}
+                />
+                <Route
+                  path="/salon/:id"
+                  element={<SalonDetails userId={userId} />}
+                />
+                <Route
+                  path="/salon/:id/book"
+                  element={<SalonBooking userId={userId} />}
+                />
                 <Route path="/bookings" element={<MyBookings />} />
                 <Route path="/bookings/:id" element={<BookingDetailsPage />} />
                 <Route path="/orders/:id" element={<OrderDetailsPage />} />
                 <Route path="/products" element={<Products />} />
                 <Route path="/products/:id" element={<ProductDetails />} />
                 <Route path="/packages" element={<Packages />} />
-                <Route path="/favorites" element={<Favorites userId={userId} userType={userType} />} />
+                <Route
+                  path="/favorites"
+                  element={<Favorites userId={userId} userType={userType} />}
+                />
                 <Route path="/about" element={<About />} />
                 <Route path="/training" element={<Training />} />
                 <Route path="/contact" element={<ContactUs />} />
                 <Route path="/account" element={<Account user={user} />} />
                 <Route path="/signin" element={<SignIn />} />
                 <Route path="/signup" element={<SignUp />} />
-                <Route path="/edit-profile" element={<EditProfile userId={userId} />} />
-                <Route path="/change-password" element={<ChangePassword userId={userId} />} />
+                <Route
+                  path="/edit-profile"
+                  element={<EditProfile userId={userId} />}
+                />
+                <Route
+                  path="/change-password"
+                  element={<ChangePassword userId={userId} />}
+                />
                 <Route path="/cart" element={<Cart />} />
                 <Route path="/checkout" element={<Checkout />} />
                 <Route path="/address" element={<AddressPage />} />
@@ -125,6 +144,7 @@ const App = () => {
 
       <ScrollToTop />
       <Footer />
+      <CookieConsent />
     </div>
   );
 };

--- a/WebsiteUser/src/components/CookieConsent.jsx
+++ b/WebsiteUser/src/components/CookieConsent.jsx
@@ -1,0 +1,58 @@
+import React, { useState, useEffect } from 'react';
+import styled from 'styled-components';
+
+const Banner = styled.div`
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  background-color: rgba(0, 0, 0, 0.9);
+  color: #fff;
+  padding: 0.75rem 1rem;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+  z-index: 1050;
+`;
+
+const Button = styled.button`
+  background-color: var(--primary);
+  border: none;
+  color: #fff;
+  padding: 0.5rem 1rem;
+  border-radius: 0.25rem;
+  cursor: pointer;
+
+  &:hover {
+    background-color: var(--primary-hover);
+  }
+`;
+
+const CookieConsent = () => {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const consent = localStorage.getItem('cookieConsent');
+    if (!consent) {
+      setVisible(true);
+    }
+  }, []);
+
+  const handleAccept = () => {
+    localStorage.setItem('cookieConsent', 'true');
+    setVisible(false);
+  };
+
+  if (!visible) return null;
+
+  return (
+    <Banner role="dialog" aria-live="polite">
+      <span>We use cookies to enhance your experience.</span>
+      <Button onClick={handleAccept}>Got it</Button>
+    </Banner>
+  );
+};
+
+export default CookieConsent;


### PR DESCRIPTION
## Summary
- add `CookieConsent` component to show a small cookie banner at the bottom
- display the cookie banner in the main App

## Testing
- `npm test --prefix WebsiteUser` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_6883690d96348327a0f8e02d0e554818