### PR TITLE
Add capitalizeName utility

### DIFF
--- a/WebsiteSalon/src/pages/Bookings.jsx
+++ b/WebsiteSalon/src/pages/Bookings.jsx
@@ -3,6 +3,7 @@ import axios from 'axios'
 import { useAuth } from '../context/AuthContext'
 import Navbar from '../components/Navbar'
 import { API_URL } from '../config'
+import capitalizeName from '../utils/capitalizeName'
 
 export default function BookingsPage() {
   const [bookings, setBookings] = useState([])
@@ -81,7 +82,7 @@ export default function BookingsPage() {
         <div className="text-center mb-5">
           <h2 className="fw-bold text-dark">📅 All Bookings</h2>
           <p className="text-muted">
-            View and manage bookings for <strong>{auth.name}</strong>
+            View and manage bookings for <strong>{capitalizeName(auth.name)}</strong>
           </p>
         </div>
 
@@ -101,7 +102,7 @@ export default function BookingsPage() {
                   <div className="card-body d-flex flex-column justify-content-between">
                     <div className="d-flex justify-content-between align-items-center mb-3">
                       <div>
-                        <h5 className="mb-1">{b.user_name}</h5>
+                        <h5 className="mb-1">{capitalizeName(b.user_name)}</h5>
                         <p
                           className="text-light mb-0"
                           style={{ fontSize: '0.9rem' }}

--- a/WebsiteSalon/src/pages/Dashboard.jsx
+++ b/WebsiteSalon/src/pages/Dashboard.jsx
@@ -15,6 +15,7 @@ import axios from 'axios'
 import { useAuth } from '../context/AuthContext'
 import Navbar from '../components/Navbar'
 import { API_URL } from '../config'
+import capitalizeName from '../utils/capitalizeName'
 
 ChartJS.register(
   BarElement,
@@ -94,7 +95,7 @@ export default function DashboardPage() {
     <>
       <Navbar />
       <div className="container mt-4">
-        <h2 className="mb-4 text-center">Welcome, {auth.name}</h2>
+        <h2 className="mb-4 text-center">Welcome, {capitalizeName(auth.name)}</h2>
 
         {/* Analytics Summary Cards */}
         <div className="row text-center mb-4 g-3">

--- a/WebsiteSalon/src/utils/capitalizeName.js
+++ b/WebsiteSalon/src/utils/capitalizeName.js
@@ -1,0 +1,10 @@
+const capitalizeName = (name) => {
+  if (!name) return ''
+  return name
+    .split(' ')
+    .filter(Boolean)
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1).toLowerCase())
+    .join(' ')
+}
+
+export default capitalizeName

--- a/WebsiteUser/src/components/layout/Navbar.jsx
+++ b/WebsiteUser/src/components/layout/Navbar.jsx
@@ -12,6 +12,7 @@ import {
   GraduationCap
 } from 'lucide-react'
 import useNavbar from '../../functionality/layout/UseNavbar'
+import capitalizeName from '../../utils/capitalizeName'
 const Navbar = ({ setUserType, userType, user }) => {
   const {
     t,
@@ -80,7 +81,7 @@ const Navbar = ({ setUserType, userType, user }) => {
                     className="fw-semibold fs-6"
                     style={{ color: '#4f8ef7' }}
                   >
-                    {user.username || t('User')}
+                    {capitalizeName(user.username) || t('User')}
                   </Dropdown.Header>
                   <Dropdown.Item
                     as={Link}

--- a/WebsiteUser/src/components/orders/BookingDetailsPage.jsx
+++ b/WebsiteUser/src/components/orders/BookingDetailsPage.jsx
@@ -4,6 +4,7 @@ import styled from 'styled-components'
 import { useTranslation } from 'react-i18next'
 import useBookingDetails from '../../functionality/orders/UseBookingDetails'
 import ServerError from '../ServerError'
+import capitalizeName from '../../utils/capitalizeName'
 
 const Container = styled.div`
   max-width: 800px;
@@ -139,9 +140,9 @@ const BookingDetailsPage = () => {
           {t('Booking')} #{booking.id}
         </Title>
 
-        <p>
-          <Label>{t('Salon')}:</Label> {booking.salon_name}
-        </p>
+          <p>
+            <Label>{t('Salon')}:</Label> {capitalizeName(booking.salon_name)}
+          </p>
 
         <p>
           <Label>{t('Status')}:</Label>{' '}

--- a/WebsiteUser/src/components/orders/MyBookings.jsx
+++ b/WebsiteUser/src/components/orders/MyBookings.jsx
@@ -5,6 +5,7 @@ import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 import useMyBookings from '../../functionality/orders/UseMyBookings';
 import ServerError from '../ServerError';
+import capitalizeName from '../../utils/capitalizeName';
 
 const Container = styled.div`
   color: #ddd;
@@ -248,7 +249,7 @@ const MyBookings = () => {
                 <div className="card-body">
                   <CardTitle className="card-title mb-2">
                     {item.type === 'booking'
-                      ? `${t('Booking at')} ${item.salon_name}`
+                      ? `${t('Booking at')} ${capitalizeName(item.salon_name)}`
                       : `${t('Order')} #${item.id}`}
                   </CardTitle>
 

--- a/WebsiteUser/src/components/products/ProductDetails.jsx
+++ b/WebsiteUser/src/components/products/ProductDetails.jsx
@@ -7,6 +7,7 @@ import { Helmet } from 'react-helmet';
 import { FaFacebook, FaTwitter } from 'react-icons/fa';
 import useProductDetails from '../../functionality/products/UseProductDetails';
 import ServerError from '../ServerError';
+import capitalizeName from '../../utils/capitalizeName';
 
 const Container = styled.div`
   display: flex;
@@ -215,7 +216,7 @@ const ProductDetails = () => {
           )}
           {product.salon_name && (
             <div style={{ marginTop: '0.5rem' }}>
-              <strong>{t('Salon')}:</strong> {product.salon_name}
+              <strong>{t('Salon')}:</strong> {capitalizeName(product.salon_name)}
             </div>
           )}
 

--- a/WebsiteUser/src/utils/capitalizeName.js
+++ b/WebsiteUser/src/utils/capitalizeName.js
@@ -1,0 +1,10 @@
+const capitalizeName = (name) => {
+  if (!name) return ''
+  return name
+    .split(' ')
+    .filter(Boolean)
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1).toLowerCase())
+    .join(' ')
+}
+
+export default capitalizeName


### PR DESCRIPTION
## Summary
- add a simple capitalizeName utility for the user and salon sites
- use the utility in the user navbar and booking/product details
- use the utility in salon dashboard and booking pages

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68836927799c8327974dae282bddab55