### PR TITLE
Add Quick View modal to product cards

### DIFF
--- a/WebsiteUser/src/components/products/Products.jsx
+++ b/WebsiteUser/src/components/products/Products.jsx
@@ -6,6 +6,7 @@ import { useNavigate, Link } from 'react-router-dom'
 import styled from 'styled-components'
 import useProducts from '../../functionality/products/UseProducts'
 import ServerError from '../ServerError'
+import QuickViewModal from './QuickViewModal'
 
 const Container = styled.div`
   color: #ddd;
@@ -97,6 +98,7 @@ const Products = () => {
   const [showFilters, setShowFilters] = useState(false)
   const [addedIds, setAddedIds] = useState([])
   const [searchTerm, setSearchTerm] = useState('')
+  const [quickViewProduct, setQuickViewProduct] = useState(null)
 
   const {
     products,
@@ -118,6 +120,9 @@ const Products = () => {
       1000
     )
   }
+
+  const openQuickView = (product) => setQuickViewProduct(product)
+  const closeQuickView = () => setQuickViewProduct(null)
 
   const currencyFormatter = new Intl.NumberFormat('en-US', {
     style: 'currency',
@@ -301,6 +306,16 @@ const Products = () => {
                   </Price>
 
                   <button
+                    className="btn btn-outline-info w-100 mb-2"
+                    onClick={(e) => {
+                      e.stopPropagation()
+                      openQuickView(product)
+                    }}
+                  >
+                    <i className="bi bi-eye me-2"></i> {t('Quick View')}
+                  </button>
+
+                  <button
                     className="btn btn-success w-100 mt-auto"
                     onClick={(e) => {
                       e.stopPropagation()
@@ -317,6 +332,15 @@ const Products = () => {
           ))}
         </div>
       )}
+      <QuickViewModal
+        show={!!quickViewProduct}
+        onHide={closeQuickView}
+        product={quickViewProduct}
+        onAddToCart={(prod, qty) => {
+          handleAddToCart(prod, qty)
+          showCheckmark(prod.id)
+        }}
+      />
     </Container>
   );
 };

--- a/WebsiteUser/src/components/products/QuickViewModal.jsx
+++ b/WebsiteUser/src/components/products/QuickViewModal.jsx
@@ -1,0 +1,62 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { Modal, Button } from 'react-bootstrap'
+import { useTranslation } from 'react-i18next'
+
+const QuickViewModal = ({ show, onHide, product, onAddToCart }) => {
+  const { t } = useTranslation()
+  if (!product) return null
+  const currencyFormatter = new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'BHD'
+  })
+  return (
+    <Modal show={show} onHide={onHide} centered>
+      <Modal.Header closeButton className="bg-dark border-secondary">
+        <Modal.Title style={{ color: '#a3c1f7' }}>{product.name}</Modal.Title>
+      </Modal.Header>
+      <Modal.Body className="bg-dark text-light">
+        {product.image_url && (
+          <img
+            src={product.image_url}
+            alt={product.name}
+            className="img-fluid rounded mb-3"
+          />
+        )}
+        <p>{product.description}</p>
+        <div className="fw-semibold mb-2">
+          {currencyFormatter.format(product.price)}
+        </div>
+        {product.quantity !== undefined && (
+          <div className="mb-3">
+            <span className="badge bg-info text-dark">
+              {t('Available')}: {product.quantity}
+            </span>
+          </div>
+        )}
+        <Button
+          variant="success"
+          className="w-100"
+          onClick={() => onAddToCart(product, product.selectedQty || 1)}
+          disabled={product.quantity <= 0}
+        >
+          <i className="bi bi-cart-plus me-2"></i> {t('Add to Cart')}
+        </Button>
+      </Modal.Body>
+      <Modal.Footer className="bg-dark border-secondary">
+        <Button variant="secondary" onClick={onHide}>
+          {t('Close')}
+        </Button>
+      </Modal.Footer>
+    </Modal>
+  )
+}
+
+QuickViewModal.propTypes = {
+  show: PropTypes.bool.isRequired,
+  onHide: PropTypes.func.isRequired,
+  product: PropTypes.object,
+  onAddToCart: PropTypes.func.isRequired
+}
+
+export default QuickViewModal

--- a/WebsiteUser/src/locales/ar/translation.json
+++ b/WebsiteUser/src/locales/ar/translation.json
@@ -228,5 +228,7 @@
   "Have questions or feedback? Fill out the form below and we'll get back to you soon.": "هل لديك أسئلة أو ملاحظات؟ املأ النموذج أدناه وسنرد عليك قريبًا.",
   "Product not found": "لم يتم العثور على المنتج",
   "Failed to load product": "فشل في تحميل المنتج",
-  "Loading product details...": "جارٍ تحميل تفاصيل المنتج..."
+  "Loading product details...": "جارٍ تحميل تفاصيل المنتج...",
+  "Quick View": "عرض سريع",
+  "Close": "إغلاق"
 }

--- a/WebsiteUser/src/locales/en/translation.json
+++ b/WebsiteUser/src/locales/en/translation.json
@@ -228,5 +228,7 @@
   "Have questions or feedback? Fill out the form below and we'll get back to you soon.": "Have questions or feedback? Fill out the form below and we'll get back to you soon.",
   "Product not found": "Product not found",
   "Failed to load product": "Failed to load product",
-  "Loading product details...": "Loading product details..."
+  "Loading product details...": "Loading product details...",
+  "Quick View": "Quick View",
+  "Close": "Close"
 }


### PR DESCRIPTION
## Summary
- enable quick product previews on Products page
- add QuickViewModal component
- support new translations for Quick View and Close

## Testing
- `npm test --silent` in `WebsiteUser`

------
https://chatgpt.com/codex/tasks/task_e_6883692b9e70832797fcf1412e270ee8